### PR TITLE
WIP: attempt to port to Agda 2.8.0 + its std-lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_build/
+*.agdai

--- a/Category.agda
+++ b/Category.agda
@@ -1,4 +1,4 @@
-module Category 
+module Category
   (Obj : Set)
   (_⇒_ : Obj -> Obj -> Set)
   (_∘_ : ∀ {a b c} -> b ⇒ c -> a ⇒ b -> a ⇒ c)
@@ -46,7 +46,7 @@ record Pullback {X Y Z}(f : X ⇒ Z)(g : Y ⇒ Z) : Set where
     isPullback : IsPullback f g P p₁ p₂
 
   open IsPullback isPullback public
-  
+
 
 record IsEqualizer {X Y}(f g : X ⇒ Y) (E : Obj) (e : E ⇒ X) : Set where
   field
@@ -61,10 +61,10 @@ record IsEqualizer {X Y}(f g : X ⇒ Y) (E : Obj) (e : E ⇒ X) : Set where
                           (e∘u≡m : e ∘ u ≡ m)
                       →   u ≡ universal m commutes
 
-    e∘universal≡m  : ∀ {Q} {m : Q ⇒ X} 
+    e∘universal≡m  : ∀ {Q} {m : Q ⇒ X}
                           {commutes : f ∘ m ≡ g ∘ m}
                       →   (e ∘ universal m commutes ≡ m)
-  
+
 record Equalizer {X Y}(f g : X ⇒ Y) : Set where
   constructor Equ_,_,_
   field
@@ -88,7 +88,7 @@ record Product (A B : Obj) : Set where
     universal : ∀ {C} {f : C ⇒ A} {g : C ⇒ B} {i : C ⇒ A×B}
                → π₁ ∘ i ≡ f → π₂ ∘ i ≡ g → ⟨ f , g ⟩ ≡ i
 
-open import Relation.Binary
+open import Relation.Binary using (IsEquivalence)
 module Props     (assoc     : ∀ {A B C D} {f : A ⇒ B} {g : B ⇒ C} {h : C ⇒ D} → (h ∘ g) ∘ f ≡ h ∘ (g ∘ f))
                  (identityˡ : ∀ {A B} {f : A ⇒ B} → id ∘ f ≡ f)
                  (identityʳ : ∀ {A B} {f : A ⇒ B} → f ∘ id ≡ f)
@@ -99,12 +99,12 @@ module Props     (assoc     : ∀ {A B C D} {f : A ⇒ B} {g : B ⇒ C} {h : C �
   module Dummy {A}{B} = IsEquivalence (equiv {A} {B})
   open Dummy
 
-  convert : {X Y Z : Obj} -> (f : X ⇒ Z)(g : Y ⇒ Z) -> (prod : Product X Y) -> let open Product prod in 
+  convert : {X Y Z : Obj} -> (f : X ⇒ Z)(g : Y ⇒ Z) -> (prod : Product X Y) -> let open Product prod in
              Equalizer (f ∘ π₁) (g ∘ π₂) -> Pullback f g
-  convert f g prod equ = Pull E , (π₁ ∘ e) , (π₂ ∘ e) , 
+  convert f g prod equ = Pull E , (π₁ ∘ e) , (π₂ ∘ e) ,
         (record {
            commutes = trans (sym assoc) (trans commutes assoc);
-           universal = λ q₁ q₂ commutes₁ → universal ⟨ q₁ , q₂ ⟩ (trans assoc (trans (∘-resp-≡ refl commute₁) 
+           universal = λ q₁ q₂ commutes₁ → universal ⟨ q₁ , q₂ ⟩ (trans assoc (trans (∘-resp-≡ refl commute₁)
                                            (trans commutes₁ (trans (sym (∘-resp-≡ refl commute₂)) (sym assoc)))));
            universal-unique = λ u p₁∘u≡q₁ p₂∘u≡q₂ → universal-unique u (sym (uniπ (trans (sym assoc) p₁∘u≡q₁) (trans (sym assoc) p₂∘u≡q₂)));
            p₁∘universal≡q₁ = trans assoc (trans (∘-resp-≡ refl e∘universal≡m) commute₁);
@@ -112,25 +112,25 @@ module Props     (assoc     : ∀ {A B C D} {f : A ⇒ B} {g : B ⇒ C} {h : C �
     where
       open Product prod renaming (universal to uniπ)
       open Equalizer equ
-  
+
   Equalizer-ext : ∀ {X Z}{f1 f2 : X ⇒ Z} -> f1 ≡ f2 -> {g1 g2 : X ⇒ Z} -> g1 ≡ g2 -> Equalizer f1 g1 -> Equalizer f2 g2
-  Equalizer-ext f1≡f2 g1≡g2 pull 
-   = Equ E , e ,   
+  Equalizer-ext f1≡f2 g1≡g2 pull
+   = Equ E , e ,
       (record {
          commutes = trans (∘-resp-≡ (sym f1≡f2) refl) (trans commutes (∘-resp-≡ g1≡g2 refl));
          universal = λ m commutes₁ → universal m (trans (∘-resp-≡ f1≡f2 refl)
                                                             (trans commutes₁ (∘-resp-≡ (sym g1≡g2) refl)));
          universal-unique = universal-unique;
          e∘universal≡m = e∘universal≡m})
-    where 
+    where
       open Equalizer pull
 
-  under-assoc : ∀ {A B C D} {f : A ⇒ B} {g : B ⇒ C} {h : C ⇒ D} -> 
+  under-assoc : ∀ {A B C D} {f : A ⇒ B} {g : B ⇒ C} {h : C ⇒ D} ->
                 ∀ {C}                  {g1 : B ⇒ C} {h1 : C ⇒ D} -> h ∘ g ≡ h1 ∘ g1 -> h ∘ (g ∘ f) ≡ h1 ∘ (g1 ∘ f)
   under-assoc eq = trans (sym assoc) (trans (∘-resp-≡ eq refl) assoc)
 
   mono-pullback-stable : ∀ {X Y Z : Obj} -> (f : X ⇒ Z)(g : Y ⇒ Z) -> (pull : Pullback f g) -> Monic g -> Monic (Pullback.p₁ pull)
-  mono-pullback-stable f g pull g-mono {C} {g1} {g2} p₁∘g1≡p₁∘g2 = 
+  mono-pullback-stable f g pull g-mono {C} {g1} {g2} p₁∘g1≡p₁∘g2 =
        trans
          (universal-unique {commutes = under-assoc commutes} g1 refl refl)
          (sym

--- a/Injections.agda
+++ b/Injections.agda
@@ -1,7 +1,6 @@
 module Injections where
 
 open import Data.Product
-open import Relation.Nullary using ()
 open import Data.Empty
 open import Data.Sum
 

--- a/Injections.agda
+++ b/Injections.agda
@@ -1,7 +1,7 @@
 module Injections where
 
 open import Data.Product
-open import Relation.Nullary
+open import Relation.Nullary using ()
 open import Data.Empty
 open import Data.Sum
 
@@ -11,11 +11,11 @@ open ≡-Reasoning
 open import Vars public
 open import Injections.Type public
 
-invert : ∀ {A : Set} {xs ys : List A} (i : Inj xs ys) → ∀ {t} (y : ys ∋ t) → Dec (∃ \ x → i $ x ≡ y) 
+invert : ∀ {A : Set} {xs ys : List A} (i : Inj xs ys) → ∀ {t} (y : ys ∋ t) → Dec (∃ \ x → i $ x ≡ y)
 invert []              y = no (λ { (() , _)})
-invert ( z ∷ i [ pf ]) y with z ≅∋? y 
+invert ( z ∷ i [ pf ]) y with z ≅∋? y
 invert (.y ∷ i [ pf ]) y | yes refl` = yes (zero , refl)
-invert ( z ∷ i [ pf ]) y | no  z≢y   with invert i y 
+invert ( z ∷ i [ pf ]) y | no  z≢y   with invert i y
 invert ( z ∷ i [ pf ]) y | no  z≢y   | yes (x , i$x≡y) = yes (suc x , i$x≡y)
 invert ( z ∷ i [ pf ]) y | no  z≢y   | no  ¬[i⁻¹y]     = no  (neither z≢y ¬[i⁻¹y])
   where
@@ -39,37 +39,37 @@ abstract
   id-i$ v = iso2 _ _ v
 
   right-id : ∀ {A : Set}{xs ys : List A} → (i : Inj xs ys) → i ∘i id-i ≡ i
-  right-id i = begin quo (λ x z → i $ (id-i $ z)) ≡⟨ quo-ext (λ x v → cong (_$_ i) (iso2 _ _ v)) ⟩ 
-                     quo (λ x → _$_ i)            ≡⟨ iso1 i (λ x eq → injective i _ _ eq) ⟩ 
+  right-id i = begin quo (λ x z → i $ (id-i $ z)) ≡⟨ quo-ext (λ x v → cong (_$_ i) (iso2 _ _ v)) ⟩
+                     quo (λ x → _$_ i)            ≡⟨ iso1 i (λ x eq → injective i _ _ eq) ⟩
                      i                            ∎
 
   left-id : ∀ {A : Set}{xs ys : List A} → (i : Inj xs ys) → id-i ∘i i ≡ i
-  left-id i = begin quo (λ x z → id-i $ (i $ z)) ≡⟨ quo-ext (λ x v → (iso2 _ _ (i $ v))) ⟩ 
-                    quo (λ x → _$_ i)            ≡⟨ iso1 i (λ x eq → injective i _ _ eq) ⟩ 
+  left-id i = begin quo (λ x z → id-i $ (i $ z)) ≡⟨ quo-ext (λ x v → (iso2 _ _ (i $ v))) ⟩
+                    quo (λ x → _$_ i)            ≡⟨ iso1 i (λ x eq → injective i _ _ eq) ⟩
                     i                            ∎
 
   apply-∘ : ∀ {A : Set}{xs ys zs : List A} → (j : Inj ys zs) → (i : Inj xs ys) → ∀ {x} {v : x ∈ xs} → (j ∘i i) $ v ≡ j $ (i $ v)
   apply-∘ j i {x}{v} = iso2 _ _ v
 
-  assoc-∘i : ∀ {A : Set}{xs ys ws zs : List A} {f : Inj ws zs}{g : Inj _ ws}{h : Inj xs ys} → f ∘i (g ∘i h) ≡ (f ∘i g) ∘i h  
-  assoc-∘i {f = f}{g = g}{h = h} = quo-ext λ x v → 
-      begin f $ (quo (λ x₁ x₂ → g $ (h $ x₂)) $ v) ≡⟨ cong (_$_ f) (iso2 _ _ v) ⟩ 
-            f $ (g $ (h $ v))                      ≡⟨ sym (iso2 _ _ (h $ v)) ⟩ 
+  assoc-∘i : ∀ {A : Set}{xs ys ws zs : List A} {f : Inj ws zs}{g : Inj _ ws}{h : Inj xs ys} → f ∘i (g ∘i h) ≡ (f ∘i g) ∘i h
+  assoc-∘i {f = f}{g = g}{h = h} = quo-ext λ x v →
+      begin f $ (quo (λ x₁ x₂ → g $ (h $ x₂)) $ v) ≡⟨ cong (_$_ f) (iso2 _ _ v) ⟩
+            f $ (g $ (h $ v))                      ≡⟨ sym (iso2 _ _ (h $ v)) ⟩
             quo (λ x₁ x₂ → f $ (g $ x₂)) $ (h $ v) ∎
 
   cong-$ : ∀ {A : Set}{xs ys : List A} {f g : _} {inj1 inj2} → quo {_} {xs} {ys} f {inj1} ≡ quo g {inj2} → ∀ {s} (x : xs ∋ s) → f s x ≡ g s x
-  cong-$ {A} {xs} {ys} {f} {g} eq x = begin f _ x     ≡⟨ sym (iso2 f _ x) ⟩ 
-                                            quo f $ x ≡⟨ cong (λ f₁ → f₁ $ x) eq ⟩ 
-                                            quo g $ x ≡⟨ iso2 g _ x ⟩ 
+  cong-$ {A} {xs} {ys} {f} {g} eq x = begin f _ x     ≡⟨ sym (iso2 f _ x) ⟩
+                                            quo f $ x ≡⟨ cong (λ f₁ → f₁ $ x) eq ⟩
+                                            quo g $ x ≡⟨ iso2 g _ x ⟩
                                             g _ x     ∎
 
   ∘i-inj : ∀ {A : Set}{xs ys zs : List A} → (i : Inj ys zs) (j1 j2 : Inj xs ys) → (i ∘i j1) ≡ (i ∘i j2) → j1 ≡ j2
-  ∘i-inj i j1 j2 eq = begin j1                 ≡⟨ sym (iso1 j1 (λ x x₁ → injective j1 _ _ x₁)) ⟩ 
-                            quo (λ x → _$_ j1) ≡⟨ quo-ext (λ x v → injective i _ _ (cong-$ eq v)) ⟩ 
-                            quo (λ x → _$_ j2) ≡⟨ iso1 j2 (λ x x₁ → injective j2 _ _ x₁) ⟩ 
+  ∘i-inj i j1 j2 eq = begin j1                 ≡⟨ sym (iso1 j1 (λ x x₁ → injective j1 _ _ x₁)) ⟩
+                            quo (λ x → _$_ j1) ≡⟨ quo-ext (λ x v → injective i _ _ (cong-$ eq v)) ⟩
+                            quo (λ x → _$_ j2) ≡⟨ iso1 j2 (λ x x₁ → injective j2 _ _ x₁) ⟩
                             j2                 ∎
-  
-  
+
+
   Inj-thin-$ : ∀ {A : Set}{x : A}{xs ys} → (v : ys ∋ x) -> (f : Inj xs (ys - v)) -> ∀ {y}(u : xs ∋ y) -> Inj-thin v f $ u ≡ thin v _ (f $ u)
   Inj-thin-$ v f u = iso2 _ _ u
 
@@ -82,8 +82,8 @@ abstract
   v∉Inj-thinv : ∀ {A : Set}{x : A}{xs ys} → (v : ys ∋ x) -> (f : Inj xs (ys - v)) -> v ∉ Inj-thin v f
   v∉Inj-thinv v f = ∉Im$-∉ (λ x x₁ → thin v _ (f $ x₁)) v (λ b → x∉thinx v (f $ b))
 
-test : ∀ {A : Set} {xs ys} → (f : ∀ (x : A) → x ∈ xs → x ∈ ys){inj1 inj2 : ∀ x → {i j : x ∈ xs} → f x i ≡ f x j → i ≡ j} → quo f {inj1} ≡ quo f {inj2}
-test f = refl
+-- test : ∀ {A : Set} {xs ys} (f : ∀ (x : A) → x ∈ xs → x ∈ ys) {inj1 inj2 : ∀ x → {i j : x ∈ xs} → f x i ≡ f x j → i ≡ j} → quo f {inj1} ≡ quo f {inj2}
+-- test f = {!!}
 
 weak : ∀ {A : Set}{x : A}{xs ys} → Inj xs ys → Inj xs (x ∷ ys)
 weak f = Inj-thin zero f
@@ -106,64 +106,63 @@ abstract
   cons-id = cong-∷[] refl (quo-ext (λ x v → cong suc (id-i$ v)))
 
   cons-∘i : ∀ {A : Set}{xs ys zs : List A}{x} → (j : Inj ys zs) → (i : Inj xs ys) → cons {A} {x} (j ∘i i) ≡ cons j ∘i cons i
-  cons-∘i j i = cong-∷[] refl (begin 
-    quo (λ x z → suc (proj₁ (quo' (λ v v₁ → j $ (i $ v₁))) $ z)) 
-      ≡⟨ quo-ext {injg = λ x x₁ → injective i _ _ (injective (weak j) _ _ x₁)} (λ x v → 
-          begin suc (proj₁ (quo' (λ v₁ v₂ → j $ (i $ v₂))) $ v) ≡⟨ cong suc (iso2 _ _ v) ⟩ 
-                suc (j $ (i $ v))                               ≡⟨ sym (iso2 _ _ (i $ v)) ⟩ 
-                quo (λ x₁ x₂ → suc (j $ x₂)) $ (i $ v)          ∎) ⟩ 
-    quo (λ x v → cons j $ suc (i $ v))                       ≡⟨ sym (quo-ext (λ x₁ v → cong (_$_ (cons j)) (iso2 (λ _ x → suc (i $ x)) _ v))) ⟩ 
+  cons-∘i j i = cong-∷[] refl (begin
+    quo (λ x z → suc (proj₁ (quo' (λ v v₁ → j $ (i $ v₁))) $ z))
+      ≡⟨ quo-ext {injg = λ x x₁ → injective i _ _ (injective (weak j) _ _ x₁)} (λ x v →
+          begin suc (proj₁ (quo' (λ v₁ v₂ → j $ (i $ v₂))) $ v) ≡⟨ cong suc (iso2 _ _ v) ⟩
+                suc (j $ (i $ v))                               ≡⟨ sym (iso2 _ _ (i $ v)) ⟩
+                quo (λ x₁ x₂ → suc (j $ x₂)) $ (i $ v)          ∎) ⟩
+    quo (λ x v → cons j $ suc (i $ v))                       ≡⟨ sym (quo-ext (λ x₁ v → cong (_$_ (cons j)) (iso2 (λ _ x → suc (i $ x)) _ v))) ⟩
     quo (λ x v → cons j $ (quo (λ z x₁ → suc (i $ x₁)) $ v)) ∎)
 
 
 ∘-ext : ∀ {A : Set}{xs ys zs ws : List A} {f : Inj ys zs}{g : Inj xs ys}{f1 : Inj ws zs}{g1 : Inj xs ws} -> f ∘i g ≡ f1 ∘i g1
-        -> (∀ x (v : xs ∋ x) -> f $ (g $ v) ≡ f1 $ (g1 $ v)) 
+        -> (∀ x (v : xs ∋ x) -> f $ (g $ v) ≡ f1 $ (g1 $ v))
 ∘-ext eq = (\ x v -> trans (sym (apply-∘ _ _)) (trans (cong (\ f -> f $ v) eq) ((apply-∘ _ _))))
 
-ext-∘ : ∀ {A : Set}{xs ys zs ws : List A} {f : Inj ys zs}{g : Inj xs ys}{f1 : Inj ws zs}{g1 : Inj xs ws} -> 
+ext-∘ : ∀ {A : Set}{xs ys zs ws : List A} {f : Inj ys zs}{g : Inj xs ys}{f1 : Inj ws zs}{g1 : Inj xs ws} ->
   (∀ x (v : xs ∋ x) -> f $ (g $ v) ≡ f1 $ (g1 $ v)) -> f ∘i g ≡ f1 ∘i g1
 ext-∘ eq = ext-$ _ _ (\ x v -> trans (apply-∘ _ _) (trans (eq x v) (sym (apply-∘ _ _))))
 
 -- Transforming pointwise representations of universal morphisms into Inj ones.
-Equ-universal-quote : ∀ {A : Set} {xs ys : List A} → (i j : Inj xs ys) → ∀ {E} → (e : Inj E xs) -> 
-               (∀ a (y : xs ∋ a) -> i $ y ≡ j $ y -> ∃ \ z -> y ≡ e $ z) ->               
+Equ-universal-quote : ∀ {A : Set} {xs ys : List A} → (i j : Inj xs ys) → ∀ {E} → (e : Inj E xs) ->
+               (∀ a (y : xs ∋ a) -> i $ y ≡ j $ y -> ∃ \ z -> y ≡ e $ z) ->
                 {as : List A} (h : Inj as xs) → i ∘i h ≡ j ∘i h → Σ (Inj as E) (λ z → e ∘i z ≡ h )
-Equ-universal-quote {A} {xs} {ys} i j {E} e c {as} h eq = 
+Equ-universal-quote {A} {xs} {ys} i j {E} e c {as} h eq =
   quo u {λ x {v} {w} eq1 → injective h v w (begin h $ v     ≡⟨ proj₂ (f x v) ⟩
                                                   e $ u x v ≡⟨ cong (_$_ e) eq1 ⟩
                                                   e $ u x w ≡⟨ sym (proj₂ (f x w)) ⟩
                                                   h $ w     ∎)}
   , ext-$ (e ∘i quo u) h (λ x v → begin
-          (e ∘i quo u) $ v ≡⟨ apply-∘ _ _ ⟩ 
+          (e ∘i quo u) $ v ≡⟨ apply-∘ _ _ ⟩
           e $ (quo u $ v)  ≡⟨ cong (_$_ e) (iso2 _ _ v) ⟩
           e $ u x v        ≡⟨ sym (proj₂ (f x v)) ⟩
           h $ v            ∎)
-  where 
+  where
    f : ∀ a (y : as ∋ a) -> ∃ \ z -> h $ y ≡ e $ z
    f a y = c a (h $ y) (∘-ext eq a y)
    u = (λ x v → proj₁ (f x v))
 
 Pull-universal-quote : ∀ {A : Set} {X Y Z : List A} → (i : Inj X Z)(j : Inj Y Z) -> ∀ {P} -> (p₁ : Inj P X) (p₂ : Inj P Y)
                  -> (∀ (a : A) (y : Y ∋ a)(x : X ∋ a) -> i $ x ≡ j $ y -> (∃ \ z -> p₁ $ z ≡ x × p₂ $ z ≡ y))
-                 -> ∀ {Q} -> (q₁ : Inj Q X) (q₂ : Inj Q Y) -> i ∘i q₁ ≡ j ∘i q₂ -> ∃ \ u -> q₁ ≡ p₁ ∘i u × q₂ ≡ p₂ ∘i u  
-Pull-universal-quote i j p₁ p₂ uni {Q} q₁ q₂ commutes = 
+                 -> ∀ {Q} -> (q₁ : Inj Q X) (q₂ : Inj Q Y) -> i ∘i q₁ ≡ j ∘i q₂ -> ∃ \ u -> q₁ ≡ p₁ ∘i u × q₂ ≡ p₂ ∘i u
+Pull-universal-quote i j p₁ p₂ uni {Q} q₁ q₂ commutes =
      quo u {λ x {v} {w} eq → injective q₁ v w (begin q₁ $ v      ≡⟨ sym (proj₁ (proj₂ (f x v))) ⟩
                                                      p₁ $ u x v  ≡⟨ cong (_$_ p₁) eq ⟩
                                                      p₁ $ u x w  ≡⟨ proj₁ (proj₂ (f x w)) ⟩
                                                      q₁ $ w      ∎)}
-     , ext-$ q₁ (p₁ ∘i quo u) (λ x v → begin 
-             q₁ $ v            ≡⟨ sym (proj₁ (proj₂ (f x v))) ⟩  
+     , ext-$ q₁ (p₁ ∘i quo u) (λ x v → begin
+             q₁ $ v            ≡⟨ sym (proj₁ (proj₂ (f x v))) ⟩
              p₁ $ u x v        ≡⟨ cong (_$_ p₁) (sym (iso2 _ _ v)) ⟩
              p₁ $ (quo u $ v)  ≡⟨ sym (apply-∘ _ _) ⟩
              (p₁ ∘i quo u) $ v ∎)
      , ext-$ q₂ (p₂ ∘i quo u) (λ x v → begin
-             q₂ $ v            ≡⟨ sym (proj₂ (proj₂ (f x v))) ⟩ 
+             q₂ $ v            ≡⟨ sym (proj₂ (proj₂ (f x v))) ⟩
              p₂ $ u x v        ≡⟨ cong (_$_ p₂) (sym (iso2 _ _ v)) ⟩
-             p₂ $ (quo u $ v)  ≡⟨ sym (apply-∘ _ _) ⟩ 
+             p₂ $ (quo u $ v)  ≡⟨ sym (apply-∘ _ _) ⟩
              (p₂ ∘i quo u) $ v ∎)
   where
     f : ∀ a (v : Q ∋ a) -> (∃ \ z -> p₁ $ z ≡ q₁ $ v × p₂ $ z ≡ q₂ $ v)
     f a v = uni a (q₂ $ v) (q₁ $ v) (∘-ext commutes a v)
     u : ∀ a (v : Q ∋ a) -> _
     u a v = proj₁ (f a v)
-

--- a/Injections/Type.agda
+++ b/Injections/Type.agda
@@ -1,7 +1,5 @@
 module Injections.Type where
 
-open import Relation.Nullary
-open import Relation.Nullary.Decidable
 open import Data.Product
 open import Data.Empty
 open import Data.Unit
@@ -12,7 +10,7 @@ open ≡-Reasoning
 
 open import Vars
 
--- Inj X Y is a first-order representation for injective maps (∀ S → X ∋ S -> Y ∋ S). 
+-- Inj X Y is a first-order representation for injective maps (∀ S → X ∋ S -> Y ∋ S).
 -- It's a little clunkier to work with but its propositional equality
 -- is extensional which saves the trouble of proving that
 -- the properties we'll care about respect the pointwise equality.
@@ -25,7 +23,7 @@ mutual
     _∷_[_] : ∀ {xs} {y} {ys : List A} (i : y ∈ xs) (is : Inj ys xs) (pf : (i ∉ is)) → Inj (y ∷ ys) xs
 
   _∉_ : ∀ {A : Set}{y : A} {xs ys} → y ∈ xs → Inj ys xs → Set
-  v ∉ []            = ⊤ 
+  v ∉ []            = ⊤
   v ∉ (u ∷ i [ _ ]) = False (v ≅∋? u) × v ∉ i
 
 proof-irr-False : ∀ {P : Set}{d : Dec P} -> (p q : False d) -> p ≡ q
@@ -37,47 +35,47 @@ proof-irr-∉ []             p        q        = refl
 proof-irr-∉ (v ∷ f [ pf ]) (Fp , p) (Fq , q) = cong₂ _,_ (proof-irr-False Fp Fq) (proof-irr-∉ f p q)
 
 cong-∷[] : ∀ {A : Set}{xs ys} {y : A}
-           {i j : y ∈ xs}      → i  ≡ j  → 
-           {is js : Inj ys xs} → is ≡ js → 
+           {i j : y ∈ xs}      → i  ≡ j  →
+           {is js : Inj ys xs} → is ≡ js →
            ∀ {pf1 pf2} → i ∷ is [ pf1 ] ≡ j ∷ js [ pf2 ]
 cong-∷[] {i = i} refl {is} refl {pf1} {pf2}  = cong (λ pf → i ∷ is [ pf ]) (proof-irr-∉ is pf1 pf2)
 
 mkFalse : ∀ {P : Set} → (P → ⊥) → ∀ {d : Dec P} → False d
 mkFalse ¬p {yes p} = ¬p p
-mkFalse ¬p {no ¬p₁} = tt 
+mkFalse ¬p {no ¬p₁} = tt
 
 fromFalse : ∀ {P : Set} {d : Dec P} → False d → P → ⊥
 fromFalse {P} {yes p} ()
 fromFalse {P} {no ¬p} _ = ¬p
 
-quo' : ∀ {A : Set} {xs ys} → (f : ∀ (x : A) → x ∈ xs → x ∈ ys){inj : ∀ x → {i j : x ∈ xs} → f x i ≡ f x j → i ≡ j} → 
+quo' : ∀ {A : Set} {xs ys} → (f : ∀ (x : A) → x ∈ xs → x ∈ ys){inj : ∀ x → {i j : x ∈ xs} → f x i ≡ f x j → i ≡ j} →
     Σ (Inj xs ys) \ is → (∀ x (i : x ∈ ys) → (∀ y j → False (i ≅∋? (f y j))) → (i ∉ is))
 quo' {_} {[]}     f {inj} = [] , (λ x i x₁ → _)
-quo' {_} {x ∷ xs} f {inj} = is , proof 
+quo' {_} {x ∷ xs} f {inj} = is , proof
  where
    rec = (quo' {_} {xs} (λ x₁ x₂ → f x₁ (suc x₂)) {(λ x₁ x₂ → suc-inj1 (inj x₁ x₂))})
 
    abstract
     pf : f x zero ∉ proj₁ (quo' (λ x₁ x₂ → f x₁ (suc x₂)) {(λ x₁ x₂ → suc-inj1 (inj x₁ x₂))})
-    pf = proj₂ rec x (f x zero) (λ y j → mkFalse (lemma y j))  
-      where 
+    pf = proj₂ rec x (f x zero) (λ y j → mkFalse (lemma y j))
+      where
         lemma : ∀ y j → f x zero ≅∋ f y (suc j) → ⊥
-        lemma .x j (refl , eq) with inj x (≅-to-≡ eq) 
+        lemma .x j (refl , eq) with inj x (≅-to-≡ eq)
         ...                       | ()
 
    is = f x zero ∷ proj₁ rec [ pf ]
-  
+
    proof : ∀ x i → (∀ y j → False (i ≅∋? (f y j))) → i ∉ is
    proof z i e = e x zero , proj₂ rec z i (λ y j → e y (suc j))
 
-quo : ∀ {A : Set} {xs ys} → (f : ∀ (x : A) → x ∈ xs → x ∈ ys){inj : ∀ x → {i j : x ∈ xs} → f x i ≡ f x j → i ≡ j} → (Inj xs ys)
+quo : ∀ {A : Set} {xs ys} → (f : ∀ (x : A) → x ∈ xs → x ∈ ys) {inj : ∀ x {i j : x ∈ xs} → f x i ≡ f x j → i ≡ j} → Inj xs ys
 quo f {inj} = proj₁ (quo' f {inj})
 
 quo-ext : ∀ {A : Set} {xs ys} → {f : ∀ (x : A) → x ∈ xs → x ∈ ys}{injf : ∀ x → {i j : x ∈ xs} → f x i ≡ f x j → i ≡ j} →
             {g : ∀ (x : A) → x ∈ xs → x ∈ ys}{injg : ∀ x → {i j : x ∈ xs} → g x i ≡ g x j → i ≡ j} →
             (∀ x v → f x v ≡ g x v) → quo f {injf} ≡ quo g {injg}
 quo-ext {A} {[]}                                 eq = refl
-quo-ext {A} {x ∷ xs} {injf = injf} {injg = injg} eq = cong-∷[] (eq _ zero) (quo-ext {injf = λ x₁ x₂ → suc-inj1 (injf x₁ x₂)} 
+quo-ext {A} {x ∷ xs} {injf = injf} {injg = injg} eq = cong-∷[] (eq _ zero) (quo-ext {injf = λ x₁ x₂ → suc-inj1 (injf x₁ x₂)}
                                                                                     {injg = λ x₁ x₂ → suc-inj1 (injg x₁ x₂)} (λ x₁ v → eq x₁ (suc v)))
 
 _$_ : ∀ {A : Set} {xs ys : List A} → Inj xs ys → ∀ {x} → x ∈ xs → x ∈ ys
@@ -87,7 +85,7 @@ _$_ : ∀ {A : Set} {xs ys : List A} → Inj xs ys → ∀ {x} → x ∈ xs → 
 
 _∉Im_ : ∀ {A : Set} {xs ys : List A} → ∀ {x} (i : x ∈ ys) → (f : Inj xs ys) → Set
 i ∉Im f = ∀ b → ¬ i ≡ f $ b
-  
+
 ∉-∉Im : ∀ {A : Set} {xs ys : List A} → (f : Inj xs ys) → ∀ {x} (i : x ∈ ys) → i ∉ f → i ∉Im f
 ∉-∉Im (i₁ ∷ f [ pf ]) .i₁ i∉f zero refl = fromFalse (proj₁ i∉f) refl`
 ∉-∉Im (i₁ ∷ f [ pf ]) i i∉f (suc b) eq = ∉-∉Im f i (proj₂ i∉f) b eq
@@ -121,6 +119,6 @@ iso1- f = iso1 f _
 ext-$ : ∀ {A : Set} {xs ys : List A} → (f g : Inj xs ys) → (∀ x (v : xs ∋ x) -> f $ v ≡ g $ v) -> f ≡ g
 ext-$ f g eq = trans (sym (iso1- f)) (trans (quo-ext {injf = λ x → injective f _ _} {injg = λ x → injective g _ _} eq) (iso1- g))
 
-∉Im$-∉ : ∀ {A : Set} {xs ys : List A} (f : ∀ x (v : x ∈ xs) → x ∈ ys){inj} 
-     → ∀ {x} (i : x ∈ ys) → (∀ (b : x ∈ xs) → i ≡ f x b → ⊥) → i ∉ (quo f {inj}) 
+∉Im$-∉ : ∀ {A : Set} {xs ys : List A} (f : ∀ x (v : x ∈ xs) → x ∈ ys){inj}
+     → ∀ {x} (i : x ∈ ys) → (∀ (b : x ∈ xs) → i ≡ f x b → ⊥) → i ∉ (quo f {inj})
 ∉Im$-∉ f {inj} i eq = ∉Im-∉ (quo f {inj}) i (λ b x → eq b (begin i ≡⟨ x ⟩ quo f $ b ≡⟨ iso2 f inj b ⟩ f _ b ∎))

--- a/MetaRens.agda
+++ b/MetaRens.agda
@@ -1,10 +1,9 @@
 module MetaRens where
 
-open import Data.Nat hiding (_≤_)
 open import Relation.Nullary
 import Relation.Nullary.Decidable as Dec
 open import Data.Empty
-open import Data.Unit hiding (_≤_)
+open import Data.Unit using (⊤)
 open import Data.Sum
 open import Data.List.Relation.Unary.All
 

--- a/MetaRens.agda
+++ b/MetaRens.agda
@@ -6,7 +6,7 @@ import Relation.Nullary.Decidable as Dec
 open import Data.Empty
 open import Data.Unit hiding (_≤_)
 open import Data.Sum
-open import Data.List.All
+open import Data.List.Relation.Unary.All
 
 open import Support.Equality
 open ≡-Reasoning
@@ -28,7 +28,7 @@ record VarClosure (D : MCtx) (S : MTy) : Set where
     ρ-env : Inj Ψ (ctx S)
     body : D ∋ (type S <<- Ψ)
 
-open VarClosure public 
+open VarClosure public
 
 map-Vc : ∀ {τ D S0 S} → Inj S0 S → VarClosure D (τ <<- S0) → VarClosure D (τ <<- S)
 map-Vc j (i / u) = ((j ∘i i) / u)
@@ -74,7 +74,7 @@ bind = _⋆_
 singleton : ∀ {G S} → (u : G ∋ S) → ∀ {Ψ} → Inj Ψ (ctx S) → MetaRen G ((G - u) <: (type S <<- Ψ))
 singleton  u j  T v with thick u v
 singleton  u j  T v | inj₁ x     = id-i / suc (proj₁ x)
-singleton .v j ._ v | inj₂ refl` = j / zero 
+singleton .v j ._ v | inj₂ refl` = j / zero
 
 singleton-refl : ∀ {G S} (u : G ∋ S) {Ψ} (i : Inj Ψ (ctx S)) → singleton u i _ u ≡ i / zero
 singleton-refl u i rewrite thick-refl u = refl
@@ -94,23 +94,23 @@ f ≡mr g = ∀ S x -> f S x ≡ g S x
 ∘mr-resp-≡  : ∀ {A B C} {f h : MetaRen B C} {g i : MetaRen A B} → f ≡mr h → g ≡mr i → (f ∘mr g) ≡mr (h ∘mr i)
 ∘mr-resp-≡ f≡h g≡i S x rewrite g≡i S x = cong (map-Vc _) (f≡h _ _)
 
-singleton-inv : ∀ {G S}(u : G ∋ S) {Ψ} (i : Inj Ψ (ctx S)) -> let f = singleton u i in 
+singleton-inv : ∀ {G S}(u : G ∋ S) {Ψ} (i : Inj Ψ (ctx S)) -> let f = singleton u i in
                  ∀ S (x : _ ∋ S) -> ∃ \ Ψ -> ∃ \ y -> ∃ \ j -> f (type S <<- Ψ) y ≡ j / x
 singleton-inv u i ._ zero    = _ , u          , i    , singleton-refl u i
 singleton-inv u i  S (suc x) = _ , thin u S x , id-i , singleton-thin u i x
 
-module MRop = Category MCtx (λ X Y → MetaRen Y X) (λ f g → g ∘mr f) idmr (λ f g → ∀ S x → f S x ≡ g S x) 
-module MRopProps = MRop.Props (λ S x → cong₂ _/_ (sym assoc-∘i) refl) (λ S x → left-map[id]) (λ S x → cong₂ _/_ (right-id _) refl) 
-             (λ {A} {B} → record { refl = λ S x₁ → refl; sym = λ x S x₁ → sym (x _ _); trans = λ x x₁ S x₂ → trans (x S x₂) (x₁ S x₂) }) 
+module MRop = Category MCtx (λ X Y → MetaRen Y X) (λ f g → g ∘mr f) idmr (λ f g → ∀ S x → f S x ≡ g S x)
+module MRopProps = MRop.Props (λ S x → cong₂ _/_ (sym assoc-∘i) refl) (λ S x → left-map[id]) (λ S x → cong₂ _/_ (right-id _) refl)
+             (λ {A} {B} → record { refl = λ S x₁ → refl; sym = λ x S x₁ → sym (x _ _); trans = λ x x₁ S x₂ → trans (x S x₂) (x₁ S x₂) })
              (λ eq₁ eq₂ S x → ∘mr-resp-≡ eq₂ eq₁ S x)
 
 id-epic : ∀ {G} -> MRop.Monic (idmr {G})
 id-epic eq S x = map-Vc-inj id-i (to-vc (eq S x))
 
-singleton-epic : ∀ {G S}(u : G ∋ S) {Ψ} (i : Inj Ψ (ctx S)) -> let f = singleton u i in 
+singleton-epic : ∀ {G S}(u : G ∋ S) {Ψ} (i : Inj Ψ (ctx S)) -> let f = singleton u i in
                  MRop.Monic f
-singleton-epic u i eq S x with singleton-inv u i S x 
-... | _ , y , j , eq' with eq _ y 
+singleton-epic u i eq S x with singleton-inv u i S x
+... | _ , y , j , eq' with eq _ y
 ... | eq'' rewrite eq' = map-Vc-inj j (to-vc eq'')
 
 eval : ∀ {p} {A : Set} {P : A → Set p} {xs : List A} →
@@ -123,16 +123,16 @@ reify : ∀ {p} {A : Set} {P : A → Set p} {xs} →
            (f : ∀ x → xs ∋ x → P x) → Σ (All P xs) \ a -> (∀ x i -> eval a x i ≡ f x i)
 reify {p} {A} {P} {[]}     f = [] , \ _ ()
 reify {p} {A} {P} {x ∷ xs} f = (f x zero ∷ proj₁ rec) , (\ { ._ zero -> refl ; _ (suc i) -> proj₂ rec _ i})
-  where rec = reify (λ x u → f x (suc u)) 
+  where rec = reify (λ x u → f x (suc u))
 
 _hasBody_ : ∀ {G}{T}(cl : VarClosure G T) {S}(x : G ∋ S) -> Set
 _hasBody_ {G} {T} cl {S} x = ∃ \ (j : Inj (ctx S) (ctx T)) -> type T ≡ type S × cl ≅ (j / x)
 
-dec-HasBody : ∀ {G}{T}(cl : VarClosure G T) {S}(x : G ∋ S) -> Dec (cl hasBody x) 
-dec-HasBody (j / y) x with y ≅∋? x 
+dec-HasBody : ∀ {G}{T}(cl : VarClosure G T) {S}(x : G ∋ S) -> Dec (cl hasBody x)
+dec-HasBody (j / y) x with y ≅∋? x
 dec-HasBody {G} {.type₁ <<- ctx₁} (j / .x) {type₁ <<- ctx} x | yes refl` = yes (j , refl`)
 dec-HasBody {G} {type <<- ctx₁} (j / y) {type₁ <<- ctx} x | no ¬p = no (aux ¬p)
-  where aux : ∀ {type}{y : _ ∋ (type <<- _)} -> (¬ (y ≅∋ x)) -> Σ (Inj ctx ctx₁) (λ j₁ → Σ (type ≡ type₁) (λ x₁ → j / y ≅ j₁ / x)) → ⊥ 
+  where aux : ∀ {type}{y : _ ∋ (type <<- _)} -> (¬ (y ≅∋ x)) -> Σ (Inj ctx ctx₁) (λ j₁ → Σ (type ≡ type₁) (λ x₁ → j / y ≅ j₁ / x)) → ⊥
         aux ¬p₁ (proj₁ , refl , eq) = ¬p₁ ((cong (_<<-_ _) (_≈vc_.Ψeq (to-vc (≅-to-≡ eq)))) , (_≈vc_.beq (to-vc (≅-to-≡ eq))))
 
 Image : ∀ {G G1} (f : MetaRen G G1) {S} (x : G1 ∋ S) -> Set
@@ -143,7 +143,7 @@ thin1 (i / zero) = i / zero
 thin1 (i / suc v) = i / (suc (suc v))
 
 epic-inv : ∀ {G G1}(f : MetaRen G G1) -> MRop.Monic f -> ∀ S (x : _ ∋ S) -> Image f x
-epic-inv f f-epic S x with any? (\ v -> dec-HasBody (f _ v) x) 
+epic-inv f f-epic S x with any? (\ v -> dec-HasBody (f _ v) x)
 epic-inv f f-epic (._ <<- _) x | yes (T , v , j , refl , eq) = _ , v , j , ≅-to-≡ eq
 epic-inv {G} {G1} f f-epic S x | no ¬p = ⊥-elim absurd where
   g1 = \ S v -> wk (singleton x id-i S v)
@@ -152,7 +152,7 @@ epic-inv {G} {G1} f f-epic S x | no ¬p = ⊥-elim absurd where
   g1∘f≡g2∘f : (g1 ∘mr f) ≡mr (g2 ∘mr f)
   g1∘f≡g2∘f S v       with f _ v    | inspect (f _) v | thick x (body (f _ v))
   g1∘f≡g2∘f S₁ v         | jfv / fv | _               | inj₁ x₁    = refl
-  g1∘f≡g2∘f (._ <<- _) v | jfv / .x | ⌞ eq ⌟          | inj₂ refl` 
+  g1∘f≡g2∘f (._ <<- _) v | jfv / .x | ⌞ eq ⌟          | inj₂ refl`
          = ⊥-elim (¬p (_ , v , jfv , refl , Het.≡-to-≅ eq))
 
   absurd : ⊥

--- a/Miller.agda-lib
+++ b/Miller.agda-lib
@@ -1,0 +1,2 @@
+include: .
+depend: standard-library

--- a/Support/EqReasoning.agda
+++ b/Support/EqReasoning.agda
@@ -1,7 +1,7 @@
 module Support.EqReasoning where
 
-open import Relation.Binary
-open import Relation.Binary.PropositionalEquality
+open import Relation.Binary using (Setoid)
+open import Relation.Binary.PropositionalEquality using (_≡_; setoid)
 import Relation.Binary.HeterogeneousEquality as H
 open H using (_≅_)
 import Relation.Binary.Reasoning.Setoid as EqR

--- a/Support/EqReasoning.agda
+++ b/Support/EqReasoning.agda
@@ -8,9 +8,9 @@ import Relation.Binary.Reasoning.Setoid as EqR
 
 open EqR public using () renaming (begin_ to begin[_]_)
 
-module _ {s₁ s₂} {S : Setoid s₁ s₂} where
+module Setoid-Reasoning {s₁ s₂} {S : Setoid s₁ s₂} where
   open EqR S public -- using (_IsRelatedTo_; _≡⟨_⟩_ )
-      hiding (begin_)
+      -- hiding (begin_)
 
   infixr 2 _≅⟨_⟩_
 
@@ -18,6 +18,6 @@ module _ {s₁ s₂} {S : Setoid s₁ s₂} where
            x ≅ y → y IsRelatedTo z → x IsRelatedTo z
   _ ≅⟨ x≅y ⟩ y≡z = _ ≡⟨ H.≅-to-≡ x≅y ⟩ y≡z
 
-module _ {a} {A : Set a} where
+module Equality-Reasoning {a} {A : Set a} where
   open EqR (setoid A) public
       using (begin_)

--- a/Support/EqReasoning.agda
+++ b/Support/EqReasoning.agda
@@ -4,12 +4,12 @@ open import Relation.Binary
 open import Relation.Binary.PropositionalEquality
 import Relation.Binary.HeterogeneousEquality as H
 open H using (_≅_)
-import Relation.Binary.EqReasoning as EqR
+import Relation.Binary.Reasoning.Setoid as EqR
 
 open EqR public using () renaming (begin_ to begin[_]_)
 
 module _ {s₁ s₂} {S : Setoid s₁ s₂} where
-  open EqR S public
+  open EqR S public -- using (_IsRelatedTo_; _≡⟨_⟩_ )
       hiding (begin_)
 
   infixr 2 _≅⟨_⟩_
@@ -21,4 +21,3 @@ module _ {s₁ s₂} {S : Setoid s₁ s₂} where
 module _ {a} {A : Set a} where
   open EqR (setoid A) public
       using (begin_)
-

--- a/Syntax.agda
+++ b/Syntax.agda
@@ -2,11 +2,13 @@ module Syntax where
 
 open import Data.Nat hiding (_≤_)
 open import Data.Empty
-open import Data.Unit hiding (_≤_)
+open import Data.Unit using (⊤)
 open import Data.Sum
 
 open import Support.Equality
 open import Support.EqReasoning
+   using (begin[_]_) renaming (module Setoid-Reasoning to EqR; module Equality-Reasoning to Eq-≡)
+
 open import Support.Product public
 
 open import Injections
@@ -19,7 +21,7 @@ open import Syntax.Equality public
 open import Syntax.RenOrn public
 
 
-congTm : ∀ {b1 b2 Sg G D T G1 D1 T1} -> b1 ≡ b2 -> (f : ∀ {b} -> Term< b > Sg G D T -> Term< b > Sg G1 D1 T1) -> 
+congTm : ∀ {b1 b2 Sg G D T G1 D1 T1} -> b1 ≡ b2 -> (f : ∀ {b} -> Term< b > Sg G D T -> Term< b > Sg G1 D1 T1) ->
          {x : Term< b1 > Sg G D T}{y : Term< b2 > Sg G D T} -> x ≅ y -> f x ≅ f y
 congTm refl f refl = refl
 
@@ -27,7 +29,7 @@ cong-∷ : ∀ {b1 b2 Sg G D T Ts} -> b1 ≡ b2 -> {x : Tm< b1 > Sg G D T}{y : T
          {xs : Tms< b1 > Sg G D Ts} {ys : Tms< b2 > Sg G D Ts} -> x ≅ y -> xs ≅ ys -> Tms._∷_ x xs ≅ Tms._∷_ y ys
 cong-∷ refl refl refl = refl
 
-cong-[] : ∀ {b1 b2 Sg G D} -> b1 ≡ b2 -> 
+cong-[] : ∀ {b1 b2 Sg G D} -> b1 ≡ b2 ->
           let xs : Tms< b1 > Sg G D []; xs = []; ys : Tms< b2 > Sg G D []; ys = [] in xs ≅ ys
 cong-[] refl = refl
 
@@ -46,15 +48,16 @@ module Subid where
   sub-id {b}     (var x ts) = congTm (x∧true≡x {b}) (var x) (subs-id ts)
   sub-id {b}     (lam t)    = congTm (x∧true≡x {b}) lam     (sub-id t)
   sub-id {true}  (mvar u j) = ≡-to-≅ (cong (mvar u) (right-id j))
-  sub-id {false} (mvar u ts) rewrite ≅-to-≡ (subs-id ts) = ≡-to-≅ (cong (mvar u) (begin 
-   reifys (build (λ z → get (evals ts idEnv) (id-i $ z))) 
-     ≡⟨ cong reifys (begin 
-          build (λ z → get (evals ts idEnv) (id-i $ z)) ≡⟨ build-ext (λ v → cong (get (evals ts idEnv)) (id-i$ v)) ⟩
-          build (get (evals ts idEnv))                  ≡⟨ build-get (evals ts idEnv) ⟩
-          evals ts idEnv                                ∎) ⟩
-   nfs ts idEnv ≡⟨ nfs-id ts ⟩
-   ts           ∎))
-  
+  sub-id {false} (mvar u ts) rewrite ≅-to-≡ (subs-id ts) = ≡-to-≅ (cong (mvar u) (begin
+      reifys (build (λ z → get (evals ts idEnv) (id-i $ z)))
+        ≡⟨ cong reifys (begin
+             build (λ z → get (evals ts idEnv) (id-i $ z)) ≡⟨ build-ext (λ v → cong (get (evals ts idEnv)) (id-i$ v)) ⟩
+             build (get (evals ts idEnv))                  ≡⟨ build-get (evals ts idEnv) ⟩
+             evals ts idEnv                                ∎) ⟩
+      nfs ts idEnv ≡⟨ nfs-id ts ⟩
+      ts           ∎))
+    where open ≡-Reasoning
+
   subs-id : ∀ {b Sg G D T} (t : Tms< b > Sg G D T) → subs id-s t ≅ t
   subs-id {b} []       = cong-[] (x∧true≡x {b})
   subs-id {b} (t ∷ ts) = cong-∷  (x∧true≡x {b}) (sub-id t) (subs-id ts)
@@ -79,19 +82,19 @@ module Sub∘ where
   sub-∘ {b3} (var x ts) = congTm (∧-assoc {b3}) (var x) (subs-∘ ts)
   sub-∘ {b3} (lam t)    = congTm (∧-assoc {b3}) lam     (sub-∘ t)
   sub-∘ {true}          {g = g} (mvar u j)  = ≡-to-≅ (sub-nat (g _ u))
-  sub-∘ {false} {f = f} {g = g} (mvar u ts) = 
-   Het.trans (≡-to-≅ (nf-nats {f = f} (evals-nats idEnv-nats (idEnv-∘ idEnv) (subs g ts)) (evals-∘ _ (idEnv-∘ idEnv) _) (g _ u))) 
+  sub-∘ {false} {f = f} {g = g} (mvar u ts) =
+   Het.trans (≡-to-≅ (nf-nats {f = f} (evals-nats idEnv-nats (idEnv-∘ idEnv) (subs g ts)) (evals-∘ idEnv {g = build injv} {h = build injv} (idEnv-∘ idEnv) (subs f (subs g ts))) (g _ u)))
              (Het.cong (replace ((f ∘s g) _ u)) (subs-∘ {f = f} {g = g} ts))
-  
+
   subs-∘ : ∀ {b3 b1 b2 Sg G1 G2 G3 D T} {f : Sub< b1 > Sg G2 G3}{g : Sub< b2 > _ _ _} (t : Tms< b3 > Sg G1 D T) → subs f (subs g t) ≅ subs (f ∘s g) t
   subs-∘ {b3} []       = cong-[] (∧-assoc {b3})
   subs-∘ {b3} (t ∷ t₁) = cong-∷ (∧-assoc {b3}) (sub-∘ t) (subs-∘ t₁)
 
- subT-∘ : ∀ {Sg G1 G2 G3 D T} {f : Sub< false > Sg G2 G3} {g : Sub< true > Sg _ _} (t : Term< true > Sg G1 D T) 
+ subT-∘ : ∀ {Sg G1 G2 G3 D T} {f : Sub< false > Sg G2 G3} {g : Sub< true > Sg _ _} (t : Term< true > Sg G1 D T)
                               → subT f (subT g t) ≡ subT (f ∘s g) t
  subT-∘ {Sg} {G1} {G2} {G3} {D} {inj₁ x} t = ≅-to-≡ (sub-∘ {true} {false} {true} t)
  subT-∘ {Sg} {G1} {G2} {G3} {D} {inj₂ y} t = ≅-to-≡ (subs-∘ {true} {false} {true} t)
- 
+
 sub-∘ : ∀ {Sg G1 G2 G3 D T} {f : Sub Sg G2 G3}{g : Sub _ _ _} (t : Tm Sg G1 D T) → sub f (sub g t) ≡ sub (f ∘s g) t
 sub-∘ t = ≅-to-≡ (Sub∘.sub-∘ {true} {true} {true} t)
 
@@ -129,24 +132,29 @@ subT-∘ {T = inj₂ _} t = subs-∘ t
 
 
 left-idf : ∀ {Sg G G1} -> (f : Sub< false > Sg G G1) -> (f ∘s id-f) ≡s f
-left-idf f S u = begin
-  eval (f S u) (evals (subs f (reifys idEnv)) idEnv) ≡⟨ eval-ext (f S u) (λ {S} x → begin[ dom ]
-           get (evals (subs f (reifys idEnv)) idEnv) x ≡⟨ cong (λ ts → get (evals ts idEnv) x) (reifys-nats idEnv-nats) ⟩ 
-           get (evals (reifys idEnv) idEnv) x          ≈⟨ RelA-unfold idEnv (idEnv-∘ idEnv) x ⟩
-           get idEnv x                                 ∎) ⟩
-  nf (f S u) idEnv                                   ≡⟨ nf-id (f S u) ⟩
-  f S u                                              ∎
+left-idf f S u = let open ≡-Reasoning in begin
+    eval (f S u) (evals (subs f (reifys idEnv)) idEnv)   ≡⟨ eval-ext (f S u) lemma  ⟩
+    nf (f S u) idEnv                                   ≡⟨ nf-id (f S u) ⟩
+    f S u  ∎
+  where
+    lemma : evals (subs f (reifys idEnv)) idEnv ≡A idEnv
+    lemma x = begin[ dom ]
+             get (evals (subs f (reifys idEnv)) idEnv) x ≡⟨ cong (λ ts → get (evals ts idEnv) x) (reifys-nats {f = f} {g1 = build injv} {g2 = build injv} idEnv-nats) ⟩
+             get (evals (reifys idEnv) idEnv) x          ≈⟨ RelA-unfold idEnv {g = build injv} {h = build injv} (idEnv-∘ idEnv) x ⟩
+             get idEnv x                                 ∎
+      where open EqR {S = dom}
 
 mutual
   right-idf : ∀ {Sg G D T} -> (t : Tm< false > Sg G D T) -> sub id-f t ≡ t
   right-idf (con c ts) = cong (con c) (rights-idf ts)
   right-idf (var x ts) = cong (var x) (rights-idf ts)
   right-idf (lam t)    = cong lam (right-idf t)
-  right-idf (mvar u ts) rewrite rights-idf ts = cong (mvar u) 
-    (begin reifys (evals (reifys idEnv) (evals ts idEnv)) ≡⟨ reifys-ext (RelA-unfold _ (idEnv-∘ (evals ts idEnv))) ⟩
+  right-idf (mvar u ts) rewrite rights-idf ts = cong (mvar u)
+    (begin reifys (evals (reifys idEnv) (evals ts idEnv)) ≡⟨ reifys-ext (RelA-unfold (evals ts idEnv) {g = build injv} {h = evals ts idEnv} (idEnv-∘ (evals ts idEnv))) ⟩
            reifys (evals ts idEnv)                        ≡⟨ refl ⟩
            nfs ts idEnv                                   ≡⟨ nfs-id ts ⟩
            ts                                             ∎)
+    where open ≡-Reasoning
 
   rights-idf : ∀ {Sg G D T} -> (t : Tms< false > Sg G D T) -> subs id-f t ≡ t
   rights-idf []       = refl
@@ -160,7 +168,7 @@ _≡d_ : ∀ {b1 b2 Sg G D T } -> (t1 : Tm< b1 > Sg G D T)(t2 : Tm< b2 > Sg G D 
 t1 ≡d t2 = ↓↓ t1 ≡ ↓↓ t2
 
 down : ∀ {b Sg G G1} -> Sub< b > Sg G G1 -> Sub< false > Sg G G1
-down {b} s = \ S u -> ↓↓ (s S u) 
+down {b} s = \ S u -> ↓↓ (s S u)
 
 ↓↓-nat : ∀ {b Sg G D D1 T } -> (i : Inj D D1) (t : Tm< b > Sg G D T) -> ↓↓ (ren i t) ≡ ren i (↓↓ t)
 ↓↓-nat {true} i t = sub-nat t
@@ -170,21 +178,23 @@ down {b} s = \ S u -> ↓↓ (s S u)
 ↓↓-comm {true}  {true}  s t = Het.sym (Sub∘.sub-∘ {f = id-f} {g = s} t)
 ↓↓-comm {true}  {false} s t = Het.trans (Het.sym (Sub∘.sub-∘ {f = id-f} {g = s} t)) (≡-to-≅ (right-idf (sub s t)))
 ↓↓-comm {false} {true}  s t = refl
-↓↓-comm {false} {false} s t = refl 
+↓↓-comm {false} {false} s t = refl
 
 ↓↓-nat₂ : ∀ {b b1 Sg G G1 D T } -> (s : Sub< b1 > Sg G G1) (t : Tm< b > Sg G D T) -> ↓↓ (sub s t) ≡ sub s (↓↓ t)
-↓↓-nat₂ {true}  {true}  s t = begin 
+↓↓-nat₂ {true}  {true}  s t = begin
   sub id-f (sub s t)          ≡⟨ ≅-to-≡ (Sub∘.sub-∘ {f = id-f} {g = s} t) ⟩
   sub (id-f ∘s s) t           ≡⟨ sym (sub-ext (left-idf (id-f ∘s s)) t) ⟩
   sub ((id-f ∘s s) ∘s id-f) t ≡⟨ sym (≅-to-≡ (Sub∘.sub-∘ {f = id-f ∘s s} {g = id-f} t)) ⟩
   sub (id-f ∘s s) (↓↓ t)      ≡⟨ ≅-to-≡ (↓↓-comm s (↓↓ t)) ⟩
   ↓↓ (sub s (↓↓ t))           ∎
-↓↓-nat₂ {true}  {false} s t = begin 
+ where open ≡-Reasoning
+↓↓-nat₂ {true}  {false} s t = begin
   sub s t            ≡⟨ sym (sub-ext (left-idf s) t) ⟩
   sub (s ∘s id-f) t  ≡⟨ ≅-to-≡ (Het.sym (Sub∘.sub-∘ {f = s} {g = id-f} t)) ⟩
   sub s (sub id-f t) ∎
+ where open ≡-Reasoning
 ↓↓-nat₂ {false} {true}  s t = refl
-↓↓-nat₂ {false} {false} s t = refl 
+↓↓-nat₂ {false} {false} s t = refl
 
 sub-extd : ∀ {b1 b2 b3 Sg G D G1 T } -> (s1 : Sub< b1 > Sg G G1)(s2 : Sub< b2 > Sg G G1) -> (t : Tm< b3 > Sg G D T) ->
             (∀ S x -> s1 S x ≡d s2 S x) -> sub s1 t ≡d sub s2 t
@@ -194,17 +204,19 @@ cong-ren : ∀ {b1 b2 Sg G D D1 T } -> (i : Inj D D1) -> {t1 : Tm< b1 > Sg G D T
            t1 ≡d t2 -> ren i t1 ≡d ren i t2
 cong-ren i {t1} {t2} eq = begin
   ↓↓ (ren i t1) ≡⟨ ↓↓-nat i t1 ⟩
-  ren i (↓↓ t1) ≡⟨ cong (ren i) eq ⟩ 
+  ren i (↓↓ t1) ≡⟨ cong (ren i) eq ⟩
   ren i (↓↓ t2) ≡⟨ sym (↓↓-nat i t2) ⟩
   ↓↓ (ren i t2) ∎
+ where open ≡-Reasoning
 
-ren-injd : ∀ {b1 b2 Sg G D D0}{T : Ty} → (i : Inj D D0) → (s : Tm< b1 > Sg G D T) (t : Tm< b2 > Sg G D T) 
+ren-injd : ∀ {b1 b2 Sg G D D0}{T : Ty} → (i : Inj D D0) → (s : Tm< b1 > Sg G D T) (t : Tm< b2 > Sg G D T)
              -> ren i s ≡d ren i t -> s ≡d t
 ren-injd i s t eq = ren-inj i (↓↓ s) (↓↓ t) (begin
   ren i (↓↓ s) ≡⟨ sym (↓↓-nat i s) ⟩
   ↓↓ (ren i s) ≡⟨ eq ⟩
   ↓↓ (ren i t) ≡⟨ ↓↓-nat i t ⟩
   ren i (↓↓ t) ∎)
+ where open ≡-Reasoning
 
 cong-↓↓ : ∀ {b1 b2 Sg G D T} -> {t1 : Tm< b1 > Sg G D T}{t2 : Tm< b2 > Sg G D T} ->
             b1 ≡ b2 -> t1 ≅ t2 -> t1 ≡d t2
@@ -217,6 +229,7 @@ cong-sub s {t1} {t2} eq = begin
   sub s (↓↓ t1) ≡⟨ cong (sub s) eq ⟩
   sub s (↓↓ t2) ≡⟨ sym (↓↓-nat₂ s t2) ⟩
   ↓↓ (sub s t2) ∎
+ where open ≡-Reasoning
 
 mutual
   sub-idf-inj : ∀ {Sg G D T} -> (s t : Tm< true > Sg G D T) -> ↓↓ s ≡T ↓↓ t -> s ≡ t
@@ -224,24 +237,24 @@ mutual
   sub-idf-inj (con c ts) (mvar u j)   ()
   sub-idf-inj (con c ts) (var x ts₁)  ()
   sub-idf-inj (mvar u j) (con c ts)   ()
-  sub-idf-inj {Sg} {G} (mvar u j) (mvar u₁ j₁) (mvar ueq x₁) = cong₂ mvar ueq 
+  sub-idf-inj {Sg} {G} (mvar u j) (mvar u₁ j₁) (mvar ueq x₁) = cong₂ mvar ueq
     (ext-$ j j₁
-     λ {(Ss ->> B) v → 
+     λ {(Ss ->> B) v →
      injective (right# Ss) _ _
-      (var-inj₀ (≡-T (begin 
+      (var-inj₀ (≡-T (let open ≡-Reasoning in begin
        var (right# Ss $ (j $ v)) (reifys (mapEnv (left# Ss) idEnv)) ≡⟨ sym (apply-injv Ss B v j) ⟩
-       eval (reify (Ss ->> B) (injv (right# Ss $ (j $ v)))) idEnv $$ 
+       eval (reify (Ss ->> B) (injv (right# Ss $ (j $ v)))) idEnv $$
          mapEnv (left# Ss) idEnv ≡⟨ (cong (λ t → eval t idEnv $$ mapEnv (left# Ss) idEnv) (hip v)) ⟩
        eval (reify (Ss ->> B) (injv (right# Ss $ (j₁ $ v)))) idEnv $$
          mapEnv (left# Ss) idEnv ≡⟨ apply-injv Ss B v j₁ ⟩
        var (right# Ss $ (j₁ $ v)) (reifys (mapEnv (left# Ss) idEnv)) ∎)))})
    where
     open import Injections.Sum
-    pointwise : ∀ {Sg G D T} -> {f g : ∀ {S} (x : T ∋ S) -> Dom Sg G D S} 
+    pointwise : ∀ {Sg G D T} -> {f g : ∀ {S} (x : T ∋ S) -> Dom Sg G D S}
            -> ∀ {S} x -> reifys (build f) ≡T reifys (build g) -> reify S (f x) ≡ reify S (g x)
     pointwise zero    (t ∷ ts) = T-≡ t
     pointwise (suc x) (t ∷ ts) = pointwise x ts
-    apply-injv : ∀ Ss B v j -> 
+    apply-injv : ∀ Ss B v j ->
                 eval (reify (Ss ->> B) (injv (right# Ss $ (j $ v)))) idEnv $$ mapEnv (left# Ss) idEnv
               ≡ var (right# Ss $ (j $ v)) (reifys (mapEnv (left# Ss) idEnv))
     apply-injv Ss B v j = begin
@@ -250,32 +263,36 @@ mutual
                                      (Rel-unfold (Ss ->> B) idEnv
                                       (injv-∘ (Ss ->> B) idEnv _ _
                                        (≡-d (get-build (injv {Sg} {G}) (right# Ss $ (j $ v))))))
-                                     {xs = mapEnv (left# Ss) idEnv} {ys = mapEnv (left# Ss) idEnv} reflA ⟩
+                                     {xs = mapEnv (left# Ss) idEnv} {ys = mapEnv (left# Ss) idEnv} (reflA {x = mapAll (mapDom (left# Ss)) (build injv)}) ⟩
       injv (right# Ss $ (j $ v)) $$ mapEnv (left# Ss) idEnv ≡⟨ injv-id (right# Ss $ (j $ v)) (mapEnv (left# Ss) idEnv) ⟩
       var (right# Ss $ (j $ v)) (reifys (mapEnv (left# Ss) idEnv)) ∎
+     where open ≡-Reasoning
 
     hip : ∀ {Ss B} (v : _ ∋ (Ss ->> B)) -> reify _ (injv (right# Ss $ (j $ v))) ≡ reify _ (injv (right# Ss $ (j₁ $ v)))
     hip {Ss} v = pointwise {f = \ x -> injv (right# Ss $ (j $ x))} {g = \ x -> injv (right# Ss $ (j₁ $ x))} v
-      (≡-T (begin 
-       reifys (build (λ x → injv (right# Ss $ (j $ x))))    ≡⟨ reifys∘build∘injv-nat j ⟩ 
-       rens (right# Ss) (rens j  (reifys idEnv))            ≡⟨ cong (rens (right# Ss)) x₁ ⟩ 
-       rens (right# Ss) (rens j₁ (reifys idEnv))            ≡⟨ sym (reifys∘build∘injv-nat j₁) ⟩ 
+      (≡-T (let open ≡-Reasoning in begin
+       reifys (build (λ x → injv (right# Ss $ (j $ x))))    ≡⟨ reifys∘build∘injv-nat j ⟩
+       rens (right# Ss) (rens j  (reifys idEnv))            ≡⟨ cong (rens (right# Ss)) x₁ ⟩
+       rens (right# Ss) (rens j₁ (reifys idEnv))            ≡⟨ sym (reifys∘build∘injv-nat j₁) ⟩
        reifys (build (λ x₂ → injv (right# Ss $ (j₁ $ x₂)))) ∎))
      where
       build∘injv-nat : ∀ j -> build (λ x → injv (right# Ss $ (j $ x))) ≡A mapEnv (right# Ss ∘i j) (build injv)
-      build∘injv-nat j {S} x = begin[ dom ] 
-       get (build (λ v₁ → injv (right# Ss $ (j $ v₁)))) x ≡⟨ get-build (λ x₂ → injv (right# Ss $ (j $ x₂))) x ⟩
-       injv (right# Ss $ (j $ x)) ≡⟨ cong injv (sym (apply-∘ (right# Ss) j)) ⟩
-       injv ((right# Ss ∘i j) $ x) ≈⟨ symd S (injv-nat (right# Ss ∘i j) x) ⟩
-       mapDom (right# Ss ∘i j) (injv x) ≡⟨ sym (cong (mapDom _) (get-build injv x)) ⟩
-       mapDom (right# Ss ∘i j) (get idEnv x) ≡⟨ sym (get-nat-≡ {f = mapDom (right# Ss ∘i j)} idEnv x) ⟩
-       get (mapEnv (right# Ss ∘i j) idEnv) x ∎
+      build∘injv-nat j {S} x = begin[ dom ]
+          get (build (λ v₁ → injv (right# Ss $ (j $ v₁)))) x ≡⟨ get-build (λ x₂ → injv (right# Ss $ (j $ x₂))) x ⟩
+          injv (right# Ss $ (j $ x)) ≡⟨ cong injv (sym (apply-∘ (right# Ss) j)) ⟩
+          injv ((right# Ss ∘i j) $ x) ≈⟨ symd S (injv-nat (right# Ss ∘i j) x) ⟩
+          mapDom (right# Ss ∘i j) (injv x) ≡⟨ sym (cong (mapDom _) (get-build injv x)) ⟩
+          mapDom (right# Ss ∘i j) (get idEnv x) ≡⟨ sym (get-nat-≡ {f = mapDom (right# Ss ∘i j)} idEnv x) ⟩
+          get (mapEnv (right# Ss ∘i j) idEnv) x ∎
+        where open EqR {S = dom}
       reifys∘build∘injv-nat : ∀ j -> reifys (build (λ x → injv (right# Ss $ (j $ x)))) ≡ rens (right# Ss) (rens j (reifys (build injv)))
-      reifys∘build∘injv-nat j = begin 
+      reifys∘build∘injv-nat j = begin
         reifys (build (λ x → injv (right# Ss $ (j $ x)))) ≡⟨ reifys-ext (build∘injv-nat j) ⟩
-        reifys (mapEnv (right# Ss ∘i j) idEnv)            ≡⟨ reifys-nat reflA (right# Ss ∘i j) ⟩
+        reifys (mapEnv (right# Ss ∘i j) idEnv)            ≡⟨ reifys-nat (reflA {x = build injv}) (right# Ss ∘i j) ⟩
         rens (right# Ss ∘i j) (reifys idEnv)              ≡⟨ rens-∘ (reifys idEnv) ⟩
         rens (right# Ss) (rens j (reifys idEnv))          ∎
+       where open ≡-Reasoning
+
   sub-idf-inj (mvar u j) (var x ts)   ()
   sub-idf-inj (var x ts) (con c ts₁)  ()
   sub-idf-inj (var x ts) (mvar u j)   ()

--- a/Syntax/NbE.agda
+++ b/Syntax/NbE.agda
@@ -1,9 +1,9 @@
 module Syntax.NbE where
 
  open import Relation.Binary.PropositionalEquality
- open import Relation.Binary
- open import Data.Sum
- open import Data.Product
+   using (_≡_; refl; sym; trans; cong; cong₂; subst; module ≡-Reasoning)
+ open import Relation.Binary using (Setoid)
+ open import Data.Product using (Σ; _,_; proj₁)
  open import Function using (_∘_)
 
  open import Data.List.Relation.Unary.All public renaming (map to mapAll)

--- a/Syntax/NbE.agda
+++ b/Syntax/NbE.agda
@@ -6,9 +6,9 @@ module Syntax.NbE where
  open import Data.Product
  open import Function using (_∘_)
 
- open import Data.List.All public renaming (map to mapAll)
+ open import Data.List.Relation.Unary.All public renaming (map to mapAll)
 
- open import Support.EqReasoning
+ import Support.EqReasoning as EqR
 
  open import Injections
 
@@ -18,14 +18,14 @@ module Syntax.NbE where
    Dom : (Sg : Ctx)(G : MCtx)(D : Ctx) → Ty → Set
    Dom Sg G D ([] ->> B) = Tm< false > Sg G D (! B)
    Dom Sg G D ((S ∷ Ss) ->> B) = Σ ((D1 : Ctx) → Inj D D1 → Dom Sg G D1 S → Dom Sg G D1 (Ss ->> B))
-     \ x → (D1 : Ctx) → (i : Inj D D1) → {s1 s2 : Dom Sg G D1 S} (s : S ∋ s1 ≡d s2) 
+     \ x → (D1 : Ctx) → (i : Inj D D1) → {s1 s2 : Dom Sg G D1 S} (s : S ∋ s1 ≡d s2)
                 → (∀ K k → (Ss ->> B) ∋ x K (k ∘i i) (mapDom k s1) ≡d mapDom k (x D1 i s2))
 
    _∋_≡d_ : ∀ {Sg G D} T → (x y : Dom Sg G D T) → Set
    ([]       ->> _) ∋ x ≡d y = x ≡ y
    ((T ∷ Ts) ->> B) ∋ x ≡d y = ∀ D i {s1 s2} (s : T ∋ s1 ≡d s2) → (Ts ->> B) ∋ proj₁ x D i s1 ≡d proj₁ y D i s2
 
- 
+
    symd : ∀ {Sg G D} T → {x y : Dom Sg G D T} → T ∋ x ≡d y → T ∋ y ≡d x
    symd ([]       ->> B) eq = sym eq
    symd ((T ∷ Ts) ->> B) eq = λ D i s → symd (Ts ->> B) (eq D i (symd T s))
@@ -36,41 +36,41 @@ module Syntax.NbE where
 
    mapDom : ∀ {Sg G D D1 T} → Inj D D1 → Dom Sg G D T → Dom Sg G D1 T
    mapDom {T = [] ->>       _} i t           = ren i t
-   mapDom {T = (_ ∷ Ts) ->> _} i (t , t-nat) = (λ D2 j s → t D2 (j ∘i i) s) , 
+   mapDom {T = (_ ∷ Ts) ->> _} i (t , t-nat) = (λ D2 j s → t D2 (j ∘i i) s) ,
      (λ D1 i₁ {s1} {s2} s K k →
       subst (λ r → Ts ->> _ ∋ t K r (mapDom k s1) ≡d mapDom k (t D1 (i₁ ∘i i) s2))
              assoc-∘i (t-nat _ (i₁ ∘i i) s K k))
 
    mapDom-id : ∀ {Sg G D T} → (d : Dom Sg G D T) → T ∋ mapDom id-i d ≡d d
    mapDom-id {T = []       ->> _} d           = ren-id d
-   mapDom-id {T = (T ∷ Ts) ->> _} (d , d-nat) = 
+   mapDom-id {T = (T ∷ Ts) ->> _} (d , d-nat) =
      λ D i s →
          transd _ (≡-d (cong (λ r → d D r _) (right-id i)))
-        (transd _ (symd _ (mapDom-id (d D i _))) 
+        (transd _ (symd _ (mapDom-id (d D i _)))
         (transd _ (symd _ (d-nat D i (refld T) _ id-i))
-        (transd _ (d-nat D i s _ id-i) 
+        (transd _ (d-nat D i s _ id-i)
                   (mapDom-id (d D i _)))))
 
    refld : ∀ {Sg G D} T → {x : Dom Sg G D T} → T ∋ x ≡d x
    refld T {x} = transd T (symd T (mapDom-id x)) (mapDom-id x)
 
    ≡-d : ∀ {Sg G D T} → {x y : Dom Sg G D T} → x ≡ y → T ∋ x ≡d y
-   ≡-d refl = refld _ 
+   ≡-d refl = refld _
 
    mapDom-∘ : ∀ {Sg G D D1 D2 T} → (j : Inj D1 D2)(i : Inj D D1) → (d : Dom Sg G D T) → T ∋ mapDom j (mapDom i d) ≡d mapDom (j ∘i i) d
    mapDom-∘ {T = [] ->>       _} j i d = sym (ren-∘ d)
-   mapDom-∘ {T = (S ∷ Ss) ->> _} j i d = λ D i₁ {s1} s → transd (Ss ->> _) (≡-d (cong (λ r → proj₁ d D r s1) (sym assoc-∘i))) 
+   mapDom-∘ {T = (S ∷ Ss) ->> _} j i d = λ D i₁ {s1} s → transd (Ss ->> _) (≡-d (cong (λ r → proj₁ d D r s1) (sym assoc-∘i)))
                                                                            (refld ((S ∷ Ss) ->> _) {d} D (i₁ ∘i (j ∘i i)) s)
 
  dom : ∀ {Sg G D T} -> Setoid _ _
- dom {Sg} {G} {D} {T} = 
+ dom {Sg} {G} {D} {T} =
      record { Carrier = Dom Sg G D T; _≈_ = _∋_≡d_ T; isEquivalence = record { refl = refld _; sym = symd _; trans = transd _ } }
 
  get : ∀ {A : Set} {P : A → Set} {xs : List A} → All P xs → (∀ {x : A} → xs ∋ x → P x)
  get (t ∷ ts) zero    = t
  get (_ ∷ ts) (suc u) = get ts u
 
- get-nat-≡ : ∀ {A : Set}{P Q : A → Set}{xs : List A} → {f : ∀ {x} → P x → Q x} → (as : All P xs) → 
+ get-nat-≡ : ∀ {A : Set}{P Q : A → Set}{xs : List A} → {f : ∀ {x} → P x → Q x} → (as : All P xs) →
              ∀ {T} (v : _ ∋ T) → get (mapAll f as) v ≡ f (get as v)
  get-nat-≡         (a ∷ as) zero    = refl
  get-nat-≡ {f = f} (a ∷ as) (suc v) = get-nat-≡ {f = f} as v
@@ -79,7 +79,7 @@ module Syntax.NbE where
  xs ≡A ys = ∀ {S} (x : _ ∋ S) → S ∋ get xs x ≡d get ys x
 
  reflA : ∀ {Sg G D T} → {x : All (Dom Sg G D) T} → x ≡A x
- reflA {x = x} = \ {S} x -> refld S
+ reflA {x = x} {S} _ = refld S
 
  mapDom-ext : ∀ {Sg G D D1 T} → (i : Inj D D1) {x y : Dom Sg G D T} → T ∋ x ≡d y → T ∋ mapDom i x ≡d mapDom i y
  mapDom-ext {T = []      ->> _} i eq = cong (ren i) eq
@@ -90,19 +90,19 @@ module Syntax.NbE where
 
  mapEnv-id : ∀ {Sg G D T} → {xs : All (Dom Sg G D) T} → mapEnv id-i xs ≡A xs
  mapEnv-id {xs = x ∷ xs} zero    = mapDom-id x
- mapEnv-id {xs = x ∷ xs} (suc v) = mapEnv-id v
+ mapEnv-id {xs = x ∷ xs} (suc v) = mapEnv-id {xs = xs} v
 
  mapEnv-ext : ∀ {Sg G D D1 T} → (i : Inj D D1) → {xs ys : All (Dom Sg G D) T} → xs ≡A ys → mapEnv i xs ≡A mapEnv i ys
- mapEnv-ext i {_ ∷ _} {_ ∷ _} eq zero    = mapDom-ext i (eq zero)
- mapEnv-ext i {_ ∷ _} {_ ∷ _} eq (suc x) = mapEnv-ext i (eq ∘ suc) x
+ mapEnv-ext i {_ ∷ xs} {_ ∷ ys} eq zero    = mapDom-ext i (eq zero)
+ mapEnv-ext i {_ ∷ xs} {_ ∷ ys} eq (suc x) = mapEnv-ext i {xs = xs} {ys = ys} (eq ∘ suc) x
 
- mapEnv-∘ : ∀ {Sg G D D1 D2 T} → (j : Inj D1 D2)(i : Inj D D1) → (xs : All (Dom Sg G D) T) 
+ mapEnv-∘ : ∀ {Sg G D D1 D2 T} → (j : Inj D1 D2)(i : Inj D D1) → (xs : All (Dom Sg G D) T)
                → mapEnv j (mapEnv i xs) ≡A mapEnv (j ∘i i) xs
  mapEnv-∘ j i (x ∷ xs) zero    = mapDom-∘ j i x
  mapEnv-∘ j i (x ∷ xs) (suc v) = mapEnv-∘ j i xs v
 
 
- cons-ext : ∀ {Sg G D T Ts} → {x y : Dom Sg G D T} → T ∋ x ≡d y 
+ cons-ext : ∀ {Sg G D T Ts} → {x y : Dom Sg G D T} → T ∋ x ≡d y
             → {xs ys : All (Dom Sg G D) Ts} → xs ≡A ys → (x ∷ xs) ≡A (y ∷ ys)
  cons-ext x xs zero    = x
  cons-ext x xs (suc v) = xs v
@@ -114,54 +114,59 @@ module Syntax.NbE where
  _∋_≡N_ {Sg} {G} {D} {T} Ts f g = (∀ D1 (i : Inj D D1) {xs ys} -> xs ≡A ys -> proj₁ f D1 i xs ≡ proj₁ g D1 i ys)
 
  reflN : ∀ {Sg G D T Ts} (f : DomN Sg G D Ts T) -> Ts ∋ f ≡N f
- reflN (f , f-nat) D i {xs} {ys} eq = begin 
+ reflN (f , f-nat) D i {xs} {ys} eq = begin
    f D i xs                         ≡⟨ sym (ren-id _) ⟩
-   ren id-i (f D i xs)              ≡⟨ sym (f-nat D i reflA D id-i) ⟩ 
+   ren id-i (f D i xs)              ≡⟨ sym (f-nat D i reflA D id-i) ⟩
    f D (id-i ∘i i) (mapEnv id-i xs) ≡⟨ f-nat D i eq D id-i ⟩
    ren id-i (f D i ys)              ≡⟨ ren-id _ ⟩
    f D i ys                         ∎
+   where open ≡-Reasoning
 
- mapDomN : ∀ {Sg G D Ts T K} (i : Inj D K) -> DomN Sg G D Ts T -> DomN Sg G K Ts T  
- mapDomN i (f , f-nat) = (λ D1 j xs → f D1 (j ∘i i) xs) 
-   , (λ D i₁ {xs} {ys} eq K k → begin[ dom ] 
-        f K ((k ∘i i₁) ∘i i) (mapEnv k xs) ≈⟨ cong₂ (f K) (sym assoc-∘i) refl ⟩ 
-        f K (k ∘i (i₁ ∘i i)) (mapEnv k xs) ≈⟨ f-nat _ (i₁ ∘i i) eq K k ⟩ 
+ mapDomN : ∀ {Sg G D Ts T K} (i : Inj D K) -> DomN Sg G D Ts T -> DomN Sg G K Ts T
+ mapDomN i (f , f-nat) = (λ D1 j xs → f D1 (j ∘i i) xs)
+   , (λ D i₁ {xs} {ys} eq K k → begin[ dom ]
+        f K ((k ∘i i₁) ∘i i) (mapEnv k xs) ≈⟨ cong₂ (f K) (sym assoc-∘i) refl ⟩
+        f K (k ∘i (i₁ ∘i i)) (mapEnv k xs) ≈⟨ f-nat _ (i₁ ∘i i) eq K k ⟩
         ren k (f D (i₁ ∘i i) ys) ∎)
+  where open EqR
 
  applyN : ∀ {Sg G D S Ss T K} -> DomN Sg G D (S ∷ Ss) T -> Inj D K -> Dom Sg G K S -> DomN Sg G K Ss T
- applyN (f , f-nat) i s = (λ D2 j xs → f D2 (j ∘i i) (mapDom j s ∷ xs)) , 
+ applyN (f , f-nat) i s = (λ D2 j xs → f D2 (j ∘i i) (mapDom j s ∷ xs)) ,
   (λ D₁ i₁ {xs} {ys} eq K k → begin[ dom ]
    f K ((k ∘i i₁) ∘i i) (mapDom (k ∘i i₁) s ∷ mapEnv k xs) ≈⟨ reflN (f , f-nat) K ((k ∘i i₁) ∘i i)
                                                                (cons-ext (symd _ (mapDom-∘ k i₁ s)) (mapEnv-ext k reflA)) ⟩
    f K ((k ∘i i₁) ∘i i) (mapEnv k (mapDom i₁ s ∷ xs))      ≈⟨ cong₂ (f K) (sym assoc-∘i) refl ⟩
    f K (k ∘i (i₁ ∘i i)) (mapEnv k (mapDom i₁ s ∷ xs))      ≈⟨ f-nat _ (i₁ ∘i i) {mapDom i₁ s ∷ xs} {mapDom i₁ s ∷ ys}
-                                                               (cons-ext (mapDom-ext i₁ (refld _)) eq) _ k ⟩ 
+                                                               (cons-ext (mapDom-ext i₁ (refld _)) eq) _ k ⟩
    ren k (f D₁ (i₁ ∘i i) (mapDom i₁ s ∷ ys)) ∎)
+  where open EqR
 
- applyN-nat : ∀ {Sg G D S Ss T D1} (f : DomN Sg G D (S ∷ Ss) T) (i : Inj D D1) -> 
-              ∀ {s1 s2 : Dom Sg G D1 S} (_ : S ∋ s1 ≡d s2) -> 
+ applyN-nat : ∀ {Sg G D S Ss T D1} (f : DomN Sg G D (S ∷ Ss) T) (i : Inj D D1) ->
+              ∀ {s1 s2 : Dom Sg G D1 S} (_ : S ∋ s1 ≡d s2) ->
               ∀ {K} (k : Inj D1 K) -> Ss ∋ applyN f (k ∘i i) (mapDom k s1) ≡N mapDomN k (applyN f i s2)
- applyN-nat (f , f-nat) i {s1} {s2} s {K} k D i₁ {xs} {ys} xs≡ys = begin 
-   f D (i₁ ∘i (k ∘i i)) (mapDom i₁ (mapDom k s1) ∷ xs) ≈⟨ cong₂ (f D) assoc-∘i refl ⟩ 
-   f D ((i₁ ∘i k) ∘i i) (mapDom i₁ (mapDom k s1) ∷ xs) ≈⟨ (reflN (f , f-nat) D ((i₁ ∘i k) ∘i i) 
-                                                           (cons-ext (transd _ (mapDom-∘ i₁ k s1) (mapDom-ext (i₁ ∘i k) s)) xs≡ys)) ⟩ 
+ applyN-nat (f , f-nat) i {s1} {s2} s {K} k D i₁ {xs} {ys} xs≡ys = begin
+   f D (i₁ ∘i (k ∘i i)) (mapDom i₁ (mapDom k s1) ∷ xs) ≈⟨ cong₂ (f D) assoc-∘i refl ⟩
+   f D ((i₁ ∘i k) ∘i i) (mapDom i₁ (mapDom k s1) ∷ xs) ≈⟨ (reflN (f , f-nat) D ((i₁ ∘i k) ∘i i)
+                                                           (cons-ext (transd _ (mapDom-∘ i₁ k s1) (mapDom-ext (i₁ ∘i k) s)) xs≡ys)) ⟩
    f D ((i₁ ∘i k) ∘i i) (mapDom (i₁ ∘i k) s2 ∷ ys)     ∎
+  where open EqR
 
 
  mutual
 
   expand : ∀ {Sg G D T} Ts → DomN Sg G D Ts T → Dom Sg G D (Ts ->> T)
   expand []       (f , f-nat) = f _ id-i []
-  expand (S ∷ Ts) (f , f-nat) = (λ D1 i s → expand Ts (applyN (f , f-nat) i s)) , 
-    (λ D1 i {s1} {s2} s K k → begin[ dom ] 
+  expand (S ∷ Ts) (f , f-nat) = (λ D1 i s → expand Ts (applyN (f , f-nat) i s)) ,
+    (λ D1 i {s1} {s2} s K k → begin[ dom ]
       expand Ts (applyN (f , f-nat) (k ∘i i) (mapDom k s1)) ≈⟨ expand-ext Ts (applyN-nat (f , f-nat) i s k) ⟩
-      expand Ts (mapDomN k (applyN (f , f-nat) i s2))       ≈⟨ expand-nat Ts (applyN (f , f-nat) i s2) (applyN (f , f-nat) i s2) 
-                                                                                 (reflN (applyN (f , f-nat) i s2)) K k ⟩ 
+      expand Ts (mapDomN k (applyN (f , f-nat) i s2))       ≈⟨ expand-nat Ts (applyN (f , f-nat) i s2) (applyN (f , f-nat) i s2)
+                                                                                 (reflN (applyN (f , f-nat) i s2)) K k ⟩
       mapDom k (expand Ts (applyN (f , f-nat) i s2)) ∎)
+    where open EqR
 
   injv : ∀ {Sg G D T} → D ∋ T → Dom Sg G D T
   injv {T = Ss ->> B} v = expand Ss ((λ D1 i xs → var (i $ v) (reifys xs)) ,
-                                    (λ D₁ i eq K k → cong₂ var (apply-∘ k i) 
+                                    (λ D₁ i eq K k → cong₂ var (apply-∘ k i)
                                                                (reifys-nat eq k)))
 
   reify : ∀ {Sg G D}(T : Ty) → Dom Sg G D T → Tm< false > Sg G D T
@@ -174,66 +179,70 @@ module Syntax.NbE where
 
   expand-nat : ∀ {Sg G D T} Ts (f g : DomN Sg G D Ts T) → (∀ D1 (i : Inj D D1) {xs ys} -> xs ≡A ys -> proj₁ f D1 i xs ≡ proj₁ g D1 i ys) ->
                 ∀ (K : List Ty) (k : Inj D K) → (Ts ->> T) ∋ expand Ts (mapDomN k f) ≡d mapDom k (expand Ts g)
-  expand-nat []       (f , f-nat) (g , g-nat) eq K k = begin 
-    f K (id-i ∘i k) []  ≡⟨ eq K (id-i ∘i k) reflA ⟩ 
-    g K (id-i ∘i k) []  ≡⟨ cong₂ (g K) (trans (left-id k) (sym (right-id k))) refl ⟩ 
-    g K (k ∘i id-i) []  ≡⟨ g-nat _ id-i reflA _ k ⟩ 
+  expand-nat []       (f , f-nat) (g , g-nat) eq K k = begin
+    f K (id-i ∘i k) []  ≡⟨ eq K (id-i ∘i k) reflA ⟩
+    g K (id-i ∘i k) []  ≡⟨ cong₂ (g K) (trans (left-id k) (sym (right-id k))) refl ⟩
+    g K (k ∘i id-i) []  ≡⟨ g-nat _ id-i reflA _ k ⟩
     ren k (g _ id-i []) ∎
-  expand-nat (T ∷ Ts) (f , _) (g , _) eq K k = λ D i {s1} {s2} s → expand-ext Ts 
-    (λ D₁ i₁ {xs} {ys} xs≡ys → begin[ dom ] 
-      f D₁ ((i₁ ∘i i) ∘i k) (mapDom i₁ s1 ∷ xs) ≈⟨ eq D₁ ((i₁ ∘i i) ∘i k) (cons-ext (mapDom-ext i₁ s) xs≡ys) ⟩ 
-      g D₁ ((i₁ ∘i i) ∘i k) (mapDom i₁ s2 ∷ ys) ≈⟨ cong₂ (g D₁) (sym assoc-∘i) refl ⟩ 
+    where open ≡-Reasoning
+  expand-nat (T ∷ Ts) (f , _) (g , _) eq K k = λ D i {s1} {s2} s → expand-ext Ts
+    (λ D₁ i₁ {xs} {ys} xs≡ys → begin[ dom ]
+      f D₁ ((i₁ ∘i i) ∘i k) (mapDom i₁ s1 ∷ xs) ≈⟨ eq D₁ ((i₁ ∘i i) ∘i k) (cons-ext (mapDom-ext i₁ s) xs≡ys) ⟩
+      g D₁ ((i₁ ∘i i) ∘i k) (mapDom i₁ s2 ∷ ys) ≈⟨ cong₂ (g D₁) (sym assoc-∘i) refl ⟩
       g D₁ (i₁ ∘i (i ∘i k)) (mapDom i₁ s2 ∷ ys) ∎)
+   where open EqR
 
   expand-ext : ∀ {Sg G D T} Ts {f g : DomN Sg G D Ts T}
                → (Ts ∋ f ≡N g) → (Ts ->> T) ∋ expand Ts f ≡d expand Ts g
-  expand-ext []       eq = eq _ id-i {[]} {[]} (λ ()) 
+  expand-ext []       eq = eq _ id-i {[]} {[]} (λ ())
   expand-ext (S ∷ Ts) eq = λ D1 i s → expand-ext Ts (λ D i₁ x → eq D (i₁ ∘i i) (cons-ext (mapDom-ext i₁ s) x))
 
 
   injv-nat : ∀ {Sg G D D1}(i : Inj D D1){T}(v : D ∋ T) → T ∋ mapDom i (injv v) ≡d (injv {Sg} {G} (i $ v))
-  injv-nat i {[]       ->> B} v = cong (\ v -> var v []) (begin 
+  injv-nat i {[]       ->> B} v = cong (\ v -> var v []) (begin
        i $ (id-i $ v) ≡⟨ cong (_$_ i) (id-i$ v) ⟩
-       i $ v          ≡⟨ sym (id-i$ (i $ v)) ⟩ 
+       i $ v          ≡⟨ sym (id-i$ (i $ v)) ⟩
        id-i $ (i $ v) ∎)
-  injv-nat i {(S ∷ Ss) ->> B} v = λ D i₁ s → expand-ext Ss (λ D₁ i₂ x → 
-    cong₂ var (begin (i₂ ∘i (i₁ ∘i i)) $ v ≡⟨ cong (λ i₃ → i₃ $ v) assoc-∘i ⟩ 
-                     ((i₂ ∘i i₁) ∘i i) $ v ≡⟨ apply-∘ (i₂ ∘i i₁) i ⟩ 
-                     (i₂ ∘i i₁) $ (i $ v)  ∎) 
+    where open ≡-Reasoning
+  injv-nat i {(S ∷ Ss) ->> B} v = λ D i₁ s → expand-ext Ss (λ D₁ i₂ x →
+    cong₂ var (begin (i₂ ∘i (i₁ ∘i i)) $ v ≡⟨ cong (λ i₃ → i₃ $ v) assoc-∘i ⟩
+                     ((i₂ ∘i i₁) ∘i i) $ v ≡⟨ apply-∘ (i₂ ∘i i₁) i ⟩
+                     (i₂ ∘i i₁) $ (i $ v)  ∎)
               (reifys-ext (cons-ext (mapDom-ext i₂ s) x)))
+    where open ≡-Reasoning
 
   injv-ext : ∀ {Sg G D T} → (v : D ∋ T) → T ∋ injv {Sg} {G} v ≡d injv v
   injv-ext {Sg} {G} {D} {Ss ->> B} v = expand-ext Ss (λ D₁ i x → cong (var _) (reifys-ext x))
 
   reify-nat : ∀ {Sg G D} T {x y : Dom Sg G D T} → T ∋ x ≡d y → ∀ {K} (k : Inj _ K) → reify T (mapDom k x) ≡ ren k (reify T y)
   reify-nat ([]       ->> _)                         eq k = cong (ren k) eq
-  reify-nat ((S ∷ Ss) ->> _) {x , x-nat} {y , y-nat} eq k 
-    = cong lam (begin
+  reify-nat ((S ∷ Ss) ->> _) {x , x-nat} {y , y-nat} eq k
+    = let open ≡-Reasoning in cong lam (begin
        reify (Ss ->> _) (x _ (weak id-i ∘i k) (injv (cons k $ zero)))         ≡⟨ reify-ext (Ss ->> _) lemma ⟩
        reify (Ss ->> _) (mapDom (cons k) (y (S ∷ _) (weak id-i) (injv zero))) ≡⟨ reify-nat (Ss ->> _) (refld (Ss ->> _)) (cons k) ⟩
        ren (cons k) (reify (Ss ->> _) (y (S ∷ _) (weak id-i) (injv zero)))    ∎)
    where
-    lemma = begin[ dom ] 
-     x _ (weak id-i ∘i k) (injv (cons k $ zero))
-       ≡⟨ cong (λ r → x _ r (injv (cons k $ zero))) (ext-∘ (λ _ v → begin
-          weak id-i $ (k $ v)             ≡⟨ iso2 _ _ (k $ v) ⟩
-          suc (id-i $ (k $ v))            ≡⟨ cong suc (id-i$ (k $ v)) ⟩
-          thin zero _ (k $ v)             ≡⟨ sym (iso2 _ _ v) ⟩
-          weak k $ v                      ≡⟨ cong (_$_ (weak k)) (sym (id-i$ v)) ⟩
-          cons k $ thin zero _ (id-i $ v) ≡⟨ cong (_$_ (cons k)) (sym (iso2 _ _ v)) ⟩
-          cons k $ (weak id-i $ v)        ∎)) ⟩
-     x _ (cons k ∘i weak id-i) (injv (cons k $ zero))        ≈⟨ eq _ (cons k ∘i weak id-i) (symd _ (injv-nat (cons k) zero)) ⟩
-     y _ (cons k ∘i weak id-i) (mapDom (cons k) (injv zero)) ≈⟨ y-nat (S ∷ _) (weak id-i) (injv-ext zero) (_ <: S) (cons k) ⟩
-     mapDom (cons k) (y _ (weak id-i) (injv zero))           ∎
-
+    lemma = begin[ dom ]
+       x _ (weak id-i ∘i k) (injv (cons k $ zero))
+         ≡⟨ cong (λ r → x _ r (injv (cons k $ zero))) (ext-∘ (λ _ v → begin
+            weak id-i $ (k $ v)             ≡⟨ iso2 _ _ (k $ v) ⟩
+            suc (id-i $ (k $ v))            ≡⟨ cong suc (id-i$ (k $ v)) ⟩
+            thin zero _ (k $ v)             ≡⟨ sym (iso2 _ _ v) ⟩
+            weak k $ v                      ≡⟨ cong (_$_ (weak k)) (sym (id-i$ v)) ⟩
+            cons k $ thin zero _ (id-i $ v) ≡⟨ cong (_$_ (cons k)) (sym (iso2 _ _ v)) ⟩
+            cons k $ (weak id-i $ v)        ∎)) ⟩
+       x _ (cons k ∘i weak id-i) (injv (cons k $ zero))        ≈⟨ eq _ (cons k ∘i weak id-i) (symd _ (injv-nat (cons k) zero)) ⟩
+       y _ (cons k ∘i weak id-i) (mapDom (cons k) (injv zero)) ≈⟨ y-nat (S ∷ _) (weak id-i) (injv-ext zero) (_ <: S) (cons k) ⟩
+       mapDom (cons k) (y _ (weak id-i) (injv zero))           ∎
+     where open EqR
   reify-ext : ∀ {Sg G D} T → {xs ys : Dom Sg G D T} → T ∋ xs ≡d ys → reify T xs ≡ reify T ys
   reify-ext ([]       ->> _) eq = eq
   reify-ext ((S ∷ Ss) ->> B) eq = cong lam (reify-ext (Ss ->> B) (eq _ (weak id-i) (injv-ext zero)))
-  
+
   reifys-nat : ∀ {Sg G D T} {x y : All (Dom Sg G D) T} → x ≡A y → ∀ {K} (k : Inj _ K) → reifys (mapEnv k x) ≡ rens k (reifys y)
   reifys-nat {x = []}     {[]}     eq k = refl
   reifys-nat {x = x ∷ xs} {y ∷ ys} eq k = cong₂ _∷_ (reify-nat _ (eq zero) k) (reifys-nat (eq ∘ suc) k)
-    
+
   reifys-ext : ∀ {Sg G D Ts} → {xs ys : All (Dom Sg G D) Ts} → xs ≡A ys → reifys xs ≡ reifys ys
   reifys-ext {xs = []}     {[]}     eq = refl
   reifys-ext {xs = x ∷ xs} {y ∷ ys} eq = cong₂ _∷_ (reify-ext _ (eq zero)) (reifys-ext (eq ∘ suc))
@@ -241,7 +250,7 @@ module Syntax.NbE where
 
  build : ∀ {A : Set} {P : A → Set} {xs : List A} → (∀ {x : A} → xs ∋ x → P x) → All P xs
  build {A} {P} {[]}     f = []
- build {A} {P} {x ∷ xs} f = f zero ∷ build (λ x₁ → f (suc x₁)) 
+ build {A} {P} {x ∷ xs} f = f zero ∷ build (λ x₁ → f (suc x₁))
 
  build-ext : ∀ {A : Set} {P : A → Set} {xs : List A}
          → {f g : ∀ {x : A} → xs ∋ x → P x} → (∀ {x : A} (v : xs ∋ x) → f v ≡ g v) → build f ≡ build g
@@ -266,15 +275,15 @@ module Syntax.NbE where
  f $$ []         = f
  f $$ (px ∷ xs₁) = proj₁ f _ id-i px $$ xs₁
 
- $$-ext : ∀ {Sg G D Ts B} → {x y : Dom Sg G D (Ts ->> B)} → _ ∋ x ≡d y → 
+ $$-ext : ∀ {Sg G D Ts B} → {x y : Dom Sg G D (Ts ->> B)} → _ ∋ x ≡d y →
           ∀ {xs ys : All (Dom Sg G D) Ts} → xs ≡A ys → (! B) ∋ (x $$ xs) ≡d (y $$ ys)
  $$-ext f {[]}     {[]}     eq = f
  $$-ext f {x ∷ xs} {y ∷ ys} eq = $$-ext (f _ id-i (eq zero)) (eq ∘ suc)
 
- $$-nat : ∀ {Sg G D Ts B} → {x y : Dom Sg G D (Ts ->> B)} → _ ∋ x ≡d y → 
+ $$-nat : ∀ {Sg G D Ts B} → {x y : Dom Sg G D (Ts ->> B)} → _ ∋ x ≡d y →
           ∀ {xs ys : All (Dom Sg G D) Ts} → xs ≡A ys → ∀ {K} (k : Inj _ K) → (! B) ∋ (mapDom k x $$ mapEnv k xs) ≡d ren k (y $$ ys)
  $$-nat                                           f≡g {[]}     {[]}     eq k = cong (ren k) f≡g
- $$-nat {Ts = T ∷ Ts} {B} {x = f , _} {g , g-nat} f≡g {x ∷ xs} {y ∷ ys} eq k = begin
+ $$-nat {Ts = T ∷ Ts} {B} {x = f , _} {g , g-nat} f≡g {x ∷ xs} {y ∷ ys} eq k = let open ≡-Reasoning in begin
    f _ (id-i ∘i k) (mapDom k x) $$ mapEnv k xs ≡⟨ $$-ext {Ts = Ts} {B = B} {x = f _ (id-i ∘i k) (mapDom k x)}
                                                     {mapDom k (g _ id-i y)} lemma
                                                     {xs = mapEnv k xs} {ys = mapEnv k ys}
@@ -287,9 +296,10 @@ module Syntax.NbE where
      f _ (k ∘i id-i) (mapDom k x) ≈⟨ f≡g _ (k ∘i id-i) (mapDom-ext k (eq zero)) ⟩
      g _ (k ∘i id-i) (mapDom k y) ≈⟨ g-nat _ id-i (refld T) _ k ⟩
      mapDom k (g _ id-i y)        ∎
+    where open EqR
 
  idEnv : ∀ {Sg G D} → All (Dom Sg G D) D
- idEnv = build injv 
+ idEnv = build injv
 
  get-nat : ∀ {Sg G D D1 T} {xs ys : All (Dom Sg G D1) D} → xs ≡A ys → (v : _ ∋ T) →
            ∀ {K} (k : Inj D1 K) → T ∋ get (mapEnv k xs) v ≡d mapDom k (get ys v)
@@ -310,16 +320,17 @@ module Syntax.NbE where
   eval (con c ts) g = con c (nfs ts g)
   eval (mvar u j) g = mvar u (nfAs j g)
   eval (var x ts) g = get g x $$ evals ts g
-  eval (lam t)    g = (λ D2 i s → eval t (s ∷ mapEnv i g)) , 
+  eval (lam t)    g = (λ D2 i s → eval t (s ∷ mapEnv i g)) ,
     (λ D1 i {s1} {s2} s K k → begin[ dom ]
        eval t (mapDom k s1 ∷ mapEnv (k ∘i i) g)     ≈⟨ eval-ext t (cons-ext (mapDom-ext k s) (λ x → symd _ (mapEnv-∘ k i _ x))) ⟩
        eval t (mapDom k s2 ∷ mapEnv k (mapEnv i g)) ≈⟨ eval-nat t reflA k ⟩
        mapDom k (eval t (s2 ∷ mapEnv i g))          ∎)
+    where open EqR
 
   evals : ∀ {b Sg G D D1 Ts} → Tms< b > Sg G D Ts → All (Dom Sg G D1) D → All (Dom Sg G D1) Ts
   evals []       g = []
   evals (t ∷ ts) g = eval t g ∷ evals ts g
-  
+
   evalAs : ∀ {b Sg G D D1 Ts} → Args b Sg G D Ts → All (Dom Sg G D1) D → All (Dom Sg G D1) Ts
   evalAs {true}  i  g = build (λ x₁ → get g (i $ x₁))
   evalAs {false} xs g = evals xs g
@@ -330,9 +341,10 @@ module Syntax.NbE where
   eval-nat (mvar u j) {xs} {ys} eq k = cong (mvar u) (nfAs-nat j eq k)
   eval-nat (var x ts) {xs} {ys} eq k = begin[ dom ]
     get (mapEnv k xs) x $$ evals ts (mapEnv k xs) ≈⟨ $$-ext {x = get (mapEnv k xs) x} {mapDom k (get ys x)} (get-nat eq x k)
-                                                       {evals ts (mapEnv k xs)} {mapEnv k (evals ts ys)} (evals-nat ts eq k) ⟩ 
+                                                       {evals ts (mapEnv k xs)} {mapEnv k (evals ts ys)} (evals-nat ts eq k) ⟩
     mapDom k (get ys x) $$ mapEnv k (evals ts ys) ≈⟨ $$-nat {x = get ys x} (refld _) {evals ts ys} reflA k ⟩
     ren k (get ys x $$ evals ts ys)               ∎
+   where open EqR
   eval-nat (lam t)    eq k = λ D i₁ s₁ → eval-ext t (cons-ext s₁ (λ x → transd _ (mapEnv-∘ i₁ k _ x) (mapEnv-ext (i₁ ∘i k) eq x)))
 
   evals-nat : ∀ {b Sg G D D1 T} (t : Tms< b > Sg G D T) {xs ys : All (Dom Sg G D1) D} → xs ≡A ys ->
@@ -346,19 +358,21 @@ module Syntax.NbE where
   evalAs-nat {true}  (u ∷ i [ _ ]) eq k (suc v) = evalAs-nat i eq k v
   evalAs-nat {false} ts            eq k v       = evals-nat ts eq k v
 
-  nfs-nat : ∀ {b Sg G D D1 T} → (ts : Tms< b > Sg G D T) → {g1 g2 : All (Dom Sg G D1) D} → g1 ≡A g2 → 
+  nfs-nat : ∀ {b Sg G D D1 T} → (ts : Tms< b > Sg G D T) → {g1 g2 : All (Dom Sg G D1) D} → g1 ≡A g2 →
             ∀ {K} (k : Inj _ K) → nfs ts (mapEnv k g1) ≡ rens k (nfs ts g2)
   nfs-nat ts {xs} {ys} eq k = begin
     reifys (evals ts (mapEnv k xs)) ≡⟨ reifys-ext (evals-nat ts eq k) ⟩
-    reifys (mapEnv k (evals ts ys)) ≡⟨ reifys-nat reflA k ⟩ 
+    reifys (mapEnv k (evals ts ys)) ≡⟨ reifys-nat reflA k ⟩
     rens k (reifys (evals ts ys))   ∎
+   where open ≡-Reasoning
 
-  nfAs-nat : ∀ {b Sg G D D1 T} → (ts : Args b Sg G D T) → {g1 g2 : All (Dom Sg G D1) D} → g1 ≡A g2 → 
+  nfAs-nat : ∀ {b Sg G D D1 T} → (ts : Args b Sg G D T) → {g1 g2 : All (Dom Sg G D1) D} → g1 ≡A g2 →
             ∀ {K} (k : Inj _ K) → nfAs ts (mapEnv k g1) ≡ rens k (nfAs ts g2)
   nfAs-nat j {xs} {ys} eq k = begin
     reifys (evalAs j (mapEnv k xs)) ≡⟨ reifys-ext (evalAs-nat j eq k) ⟩
     reifys (mapEnv k (evalAs j ys)) ≡⟨ reifys-nat reflA k ⟩
     rens k (reifys (evalAs j ys))   ∎
+   where open ≡-Reasoning
 
   eval-ext : ∀ {b Sg G D D1 T} → (t : Tm< b > Sg G D T) → {g1 g2 : All (Dom Sg G D1) D} →
              g1 ≡A g2 → T ∋ eval t g1 ≡d eval t g2
@@ -376,7 +390,7 @@ module Syntax.NbE where
   evalAs-ext {true}  (i ∷ t [ pf ]) eq zero    = eq i
   evalAs-ext {true}  (i ∷ t [ pf ]) eq (suc x) = evalAs-ext t eq x
   evalAs-ext {false} t              eq x       = evals-ext t eq x
- 
+
   nf-ext : ∀ {b Sg G D D1 T} → (t : Tm< b > Sg G D T) → {g1 g2 : All (Dom Sg G D1) D} → g1 ≡A g2 → nf t g1 ≡ nf t g2
   nf-ext t g = reify-ext _ (eval-ext t g)
 
@@ -397,21 +411,22 @@ module Syntax.NbE where
  ≤[]-∘ : ∀ {Sg G B C} → (f : All (Dom Sg G C) B) ->
               ∀ {D} (i : Inj B D) {K} (j : Inj C K) → ∀ (f' : All (Dom Sg G K) D)
               → mapEnv j f ≤[ i ] f' → ∀ {D'} (i' : Inj D D') {K'} (j' : Inj K K') → ∀ (f'' : All (Dom Sg G K') D')
-              → mapEnv j' f' ≤[ i' ] f'' → mapEnv (j' ∘i j) f ≤[ (i' ∘i i) ] f'' 
+              → mapEnv j' f' ≤[ i' ] f'' → mapEnv (j' ∘i j) f ≤[ (i' ∘i i) ] f''
  ≤[]-∘ f i j f' ex i' j' f'' ex' {S} x = begin[ dom ]
-  get (mapEnv (j' ∘i j) f) x     ≈⟨ symd S (mapEnv-∘ j' j f x) ⟩
-  get (mapEnv j' (mapEnv j f)) x ≈⟨ get-nat reflA x j' ⟩
-  mapDom j' (get (mapEnv j f) x) ≈⟨ mapDom-ext j' (ex x) ⟩
-  mapDom j' (get f' (i $ x))     ≈⟨ symd _ (get-nat reflA (i $ x) j') ⟩
-  get (mapEnv j' f') (i $ x)     ≈⟨ ex' (i $ x) ⟩
-  get f'' (i' $ (i $ x))         ≡⟨ cong (get f'') (sym (apply-∘ i' i)) ⟩
-  get f'' ((i' ∘i i) $ x)        ∎
+     get (mapEnv (j' ∘i j) f) x     ≈⟨ symd S (mapEnv-∘ j' j f x) ⟩
+     get (mapEnv j' (mapEnv j f)) x ≈⟨ get-nat reflA x j' ⟩
+     mapDom j' (get (mapEnv j f) x) ≈⟨ mapDom-ext j' (ex x) ⟩
+     mapDom j' (get f' (i $ x))     ≈⟨ symd _ (get-nat reflA (i $ x) j') ⟩
+     get (mapEnv j' f') (i $ x)     ≈⟨ ex' (i $ x) ⟩
+     get f'' (i' $ (i $ x))         ≡⟨ cong (get f'') (sym (apply-∘ i' i)) ⟩
+     get f'' ((i' ∘i i) $ x)        ∎
+   where open EqR
 
- idEnv-≤[] : ∀ {Sg G D} {D1} (i : Inj D D1) → mapEnv i (idEnv {Sg} {G}) ≤[ i ] idEnv 
- idEnv-≤[] i {S} x = begin[ dom ] 
-   get (mapEnv i idEnv) x                  ≡⟨ cong (λ g → get g x) (mapAll-build _ injv (mapDom i)) ⟩
-   get (build (λ v → mapDom i (injv v))) x ≡⟨ get-build (λ x₁ → mapDom i (injv x₁)) x ⟩
-   mapDom i (injv x)                       ≈⟨ injv-nat i x ⟩ 
-   injv (i $ x)                            ≡⟨ sym (get-build injv (i $ x)) ⟩
-   get idEnv (i $ x)                       ∎
-
+ idEnv-≤[] : ∀ {Sg G D} {D1} (i : Inj D D1) → mapEnv i (idEnv {Sg} {G}) ≤[ i ] idEnv
+ idEnv-≤[] i {S} x = begin[ dom ]
+     get (mapEnv i idEnv) x                  ≡⟨ cong (λ g → get g x) (mapAll-build _ injv (mapDom i)) ⟩
+     get (build (λ v → mapDom i (injv v))) x ≡⟨ get-build (λ x₁ → mapDom i (injv x₁)) x ⟩
+     mapDom i (injv x)                       ≈⟨ injv-nat i x ⟩
+     injv (i $ x)                            ≡⟨ sym (get-build injv (i $ x)) ⟩
+     get idEnv (i $ x)                       ∎
+   where open EqR

--- a/Syntax/No-Cycle.agda
+++ b/Syntax/No-Cycle.agda
@@ -38,37 +38,31 @@ renT-height {inj₁ ._} i (lam t) = cong suc (renT-height _ t)
 renT-height {inj₂ .[]} i [] = refl
 renT-height {inj₂ ._} i (t ∷ t₁) = cong₂ (\ x y -> suc (x ⊔ y)) (renT-height i t) (renT-height i t₁)
 
-open import Data.Nat  
-
-private
-  n≤m⊔n : ∀ m n → (m ⊔ n) ≥ n
-  n≤m⊔n zero    _       = begin _ ∎
-  n≤m⊔n (suc m) zero    = z≤n
-  n≤m⊔n (suc m) (suc n) = s≤s (n≤m⊔n m n)
+open import Data.Nat
 
 wrapD-height : ∀ {Sg G DI TI DO TO b} → (d : DTm< b > Sg G (DI , TI) (DO , TO)) → (t : Term< b > Sg G DO TO) → heightT (wrapD d t) > heightT t
 wrapD-height lam       t = s≤s (begin heightT t ∎)
 wrapD-height (head ts) t = s≤s (m≤m⊔n (height t) (heights ts))
-wrapD-height (tail t) ts = s≤s (n≤m⊔n (height t) (heights ts))
+wrapD-height (tail t) ts = s≤s (m≤n⊔m (height t) (heights ts))
 wrapD-height (con c)  ts = s≤s (begin heightT ts ∎)
 wrapD-height (var x)  ts = s≤s (begin heightT ts ∎)
 
 wrap-height : ∀ {Sg G I O b} → (C : Context< b > Sg G I O) → (t : Term< b > Sg G (proj₁ O) (proj₂ O)) → heightT (wrap C t) ≥ heightT t
 wrap-height []      t = begin heightT t ∎
-wrap-height (d ∷ c) t = begin heightT t                    ≤⟨ ≤-step (wrap-height c t) ⟩ 
-                              suc (heightT (wrap c t))     ≤⟨ wrapD-height d (wrap c t) ⟩ 
+wrap-height (d ∷ c) t = begin heightT t                    ≤⟨ m≤n⇒m≤1+n (wrap-height c t) ⟩
+                              suc (heightT (wrap c t))     ≤⟨ wrapD-height d (wrap c t) ⟩
                               heightT (wrapD d (wrap c t)) ∎
 
-No-Cycle : ∀ {b TI Sg G D1 DI DO X} -> let TO = TI in 
-         (d : DTm< b > Sg G (DI , TI) X) (c : Context< b > Sg G X (DO , TO)) 
-         (t : Term< b > Sg G D1 TO) (i : Inj D1 DI)(j : Inj D1 DO) -> 
+No-Cycle : ∀ {b TI Sg G D1 DI DO X} -> let TO = TI in
+         (d : DTm< b > Sg G (DI , TI) X) (c : Context< b > Sg G X (DO , TO))
+         (t : Term< b > Sg G D1 TO) (i : Inj D1 DI)(j : Inj D1 DO) ->
          ¬ renT i t ≡ wrap (d ∷ c) (renT j t)
-No-Cycle d c t i j eq = ≡-or-> (cong heightT eq) 
+No-Cycle d c t i j eq = ≡-or-> (cong heightT eq)
            (begin
               suc (heightT (renT i t))              ≡⟨ cong suc (sym (renT-height i t)) ⟩
               suc (heightT t)                       ≡⟨ cong suc (renT-height j t) ⟩
               suc (heightT (renT j t))              ≤⟨ s≤s (wrap-height c (renT j t)) ⟩
-              suc (heightT (wrap c (renT j t)))     ≤⟨ wrapD-height d (wrap c (renT j t)) ⟩ 
+              suc (heightT (wrap c (renT j t)))     ≤⟨ wrapD-height d (wrap c (renT j t)) ⟩
               heightT (wrapD d (wrap c (renT j t))) ∎)
   where
     ≡-or-> : ∀ {m n} -> m ≡ n -> n > m -> ⊥

--- a/Syntax/RenOrn.agda
+++ b/Syntax/RenOrn.agda
@@ -1,5 +1,6 @@
 module Syntax.RenOrn where
 
+open import Axiom.UniquenessOfIdentityProofs.WithK using () renaming (uip to proof-irrelevance)
 open import Relation.Binary.PropositionalEquality
 open import Data.Sum
 open import Data.Bool
@@ -12,7 +13,7 @@ open import Syntax.Type
 
 -- RTm i t is the inductive version of Σ (Tm Sg G D T) λ s → ren i s ≡ t
 -- In the language of "Ornamental Algebras, Algebraic Ornaments" RTm i t
--- would be the latter and we'd get both RTm and the remember/forget 
+-- would be the latter and we'd get both RTm and the remember/forget
 -- conversions for free by expressing ren i as a fold.
 mutual
   data RTm {b : Bool} {Sg : Ctx}{G : MCtx}{D : Ctx}{K : Ctx} (i : Inj D K) : {T : Ty} → Tm< b > Sg G K T → Set where
@@ -43,7 +44,7 @@ mutual
   forget {true}  (mvar u (j , eq)) = mvar u j , cong (mvar u) eq
   forget {false} (mvar u ts)       = mapΣ (mvar u) (cong (mvar u)) (forgets ts)
   forget {i = i} (var v refl x₂)   = mapΣ (var v) (cong (var (i $ v))) (forgets x₂)
-  forget         (lam x)           = mapΣ lam (cong lam) (forget x) 
+  forget         (lam x)           = mapΣ lam (cong lam) (forget x)
 
   forgets : ∀ {b Sg G D D0}{Ts} → {i : Inj D D0} → {t : Tms< b > Sg G D0 Ts} → (x : RTms i t) → Σ (Tms< b > Sg G D Ts) \ s → rens i s ≡ t
   forgets []       = [] , refl
@@ -72,10 +73,10 @@ mutual
   unique         (lam x)          (lam y)      = cong lam (unique x y)
   unique {false} (mvar u xs)      (mvar .u ys) = cong (mvar u) (uniques xs ys)
   unique {i = i} (var v i$v≡x xs) (var  w i$w≡x ys) with injective i v w (trans i$v≡x (sym i$w≡x))
-  unique         (var v i$v≡x xs) (var .v i$w≡x ys)    | refl 
+  unique         (var v i$v≡x xs) (var .v i$w≡x ys)    | refl
     = cong₂ (λ a b → var v a b) (proof-irrelevance i$v≡x i$w≡x) (uniques xs ys)
   unique {true} {i = i} (mvar u (j , i∘j≡k)) (mvar .u (j₁ , i∘j₁≡k)) with ∘i-inj i j j₁ (trans i∘j≡k (sym i∘j₁≡k))
-  unique {true} {i = i} (mvar u (j , i∘j≡k)) (mvar .u (.j , i∘j₁≡k))    | refl 
+  unique {true} {i = i} (mvar u (j , i∘j≡k)) (mvar .u (.j , i∘j₁≡k))    | refl
     = cong (λ e → mvar u (j , e)) (proof-irrelevance i∘j≡k i∘j₁≡k)
 
   uniques : ∀ {b Sg G D D0}{Ss : Fwd Ty} → {i : Inj D D0} → {t : Tms< b > Sg G D0 Ss} → (x y : RTms i t) → x ≡ y
@@ -83,6 +84,6 @@ mutual
   uniques (x ∷ xs) (y ∷ ys) = cong₂ _∷_ (unique x y) (uniques xs ys)
 
 ren-inj : ∀ {b Sg G D D0}{T : Ty} → (i : Inj D D0) → (s t : Tm< b > Sg G D T) -> ren i s ≡ ren i t -> s ≡ t
-ren-inj i s t eq 
+ren-inj i s t eq
  with remember i s   | remember i t
 ... | (rs , fogrs≡s) | (rt , fogrt≡t) rewrite eq = trans (sym fogrs≡s) (trans (cong (λ r → proj₁ (forget r)) (unique rs rt)) fogrt≡t)

--- a/Syntax/Sub.agda
+++ b/Syntax/Sub.agda
@@ -22,7 +22,7 @@ Sub = Sub< true >
 
 _≡s_ : ∀ {b Sg G G1}(s s₁ : Sub< b > Sg G G1) → Set
 s ≡s s₁ = ∀ S u → s S u ≡ s₁ S u
- 
+
 thin-s : ∀ {Sg}{G T} → (u : G ∋ T) → Sub Sg (G - u) G
 thin-s u = \ S v → mvar (thin u S v) id-i
 
@@ -47,7 +47,7 @@ id-f = \ S u → mvar u (reifys idEnv)
 _∘s_ : ∀ {b1 b2 Sg G1 G2 G3} → Sub< b1 > Sg G2 G3 → Sub< b2 > Sg G1 G2 → Sub< b2 ∧ b1 > Sg G1 G3
 r ∘s s = λ S x → sub r (s S x)
 
--- f ≤ g iff g can be specialized to f 
+-- f ≤ g iff g can be specialized to f
 _≤_ : ∀ {Sg G G1 G2 b} → Sub< b > Sg G G1 → Sub Sg G G2 → Set
 f ≤ g = ∃ \ r → ∀ S u → f S u ≡ (r ∘s g) S u
 
@@ -68,73 +68,73 @@ mutual
 RelId : ∀ {Sg G D Ts} → (y : All (Dom Sg G D) Ts) → Set
 RelId f = RelA idEnv f f
 
-get-nats : ∀ {b1 Sg G1 G2 D1 D2} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2} 
+get-nats : ∀ {b1 Sg G1 G2 D1 D2} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2}
            → Env-nats f g1 g2 → ∀ {T} x → Dom-nats T f (get g1 x) (get g2 x)
 get-nats {g1 = _ ∷ _} {_ ∷ _} (dnat , _) zero = dnat
 get-nats {g1 = _ ∷ _} {_ ∷ _} (_ , enat) (suc x) = get-nats enat x
- 
+
 mutual
   sub-nat : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {i : Inj D1 D2} (t : Tm< b2 > Sg G1 D1 T) → sub f (ren i t) ≡ ren i (sub f t)
   sub-nat                          (con c ts)  = cong (con c) (subs-nat ts)
   sub-nat                          (var x ts)  = cong (var _) (subs-nat ts)
   sub-nat                          (lam t)     = cong lam (sub-nat t)
   sub-nat {b1} {true}              (mvar u j)  = ren-∘ _
-  sub-nat {b1} {false} {f = f} {i} (mvar u xs) = begin 
-    replace (f _ u) (subs f (rens i xs))              ≡⟨ cong (replace (f _ u)) (subs-nat xs) ⟩ 
+  sub-nat {b1} {false} {f = f} {i} (mvar u xs) = begin
+    replace (f _ u) (subs f (rens i xs))              ≡⟨ cong (replace (f _ u)) (subs-nat xs) ⟩
     replace (f _ u) (rens i (subs f xs))              ≡⟨ eval-ext (f _ u) (evals-square (subs f xs) i i (idEnv-≤[] i)) ⟩
-    eval (f _ u) (mapEnv i (evals (subs f xs) idEnv)) ≡⟨ eval-nat (f _ u) reflA i ⟩ 
+    eval (f _ u) (mapEnv i (evals (subs f xs) idEnv)) ≡⟨ eval-nat (f _ u) (reflA {x = evals (subs f xs) idEnv}) i ⟩
     ren i (sub f (mvar u xs))                         ∎
-  
+
   subs-nat : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {i : Inj D1 D2} (t : Tms< b2 > Sg G1 D1 T) → subs f (rens i t) ≡ rens i (subs f t)
   subs-nat []       = refl
   subs-nat (t ∷ ts) = cong₂ _∷_ (sub-nat t) (subs-nat ts)
 
 mutual
-  eval-nats : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2} 
+  eval-nats : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2}
               → Env-nats f g1 g2 → RelId g2 → (t : Tm< b2 > Sg G1 D2 T) → Dom-nats T f (eval t g1) (eval (sub f t) g2)
   eval-nats g gr (con c ts) = cong (con c) (nfs-nats g gr ts)
-  eval-nats g gr (var x ts) = $$-nats _ (get-nats g x) (evals-nats g gr ts) (evals-∘ idEnv gr _)
-  eval-nats g gr (lam t)    = λ D1 r sr x → eval-nats (x , mapEnv-nats _ _ r g) 
-       (λ { {._} zero → sr; {S} (suc v) → mapRelA idEnv gr r r idEnv (idEnv-≤[] r) v }) t
-  eval-nats {_} {true}  {f = f} {g1} {g2} g gr (mvar u j)  = begin 
-    eval (f _ u) (evals (subs f (reifys (build (λ x₁ → get g1 (j $ x₁))))) idEnv) 
-        ≡⟨ cong (λ ts → eval (f _ u) (evals ts idEnv)) (reifys-nats {f = f} (evalAs-nats g j)) ⟩ 
+  eval-nats {f = f} {g1 = g1} {g2 = g2} g gr (var x ts) = $$-nats _ (get-nats g x) (evals-nats g gr ts) (evals-∘ idEnv {g = g2} {h = g2} gr (subs f ts))
+  eval-nats {f = f} {g1 = g1} {g2 = g2} g gr (lam t)    = λ D1 r sr x → eval-nats (x , mapEnv-nats _ _ r g)
+       (λ { {._} zero → sr; {S} (suc v) → mapRelA idEnv {g = g2} {h = g2} gr r r idEnv (idEnv-≤[] r) v }) t
+  eval-nats {_} {true}  {f = f} {g1} {g2} g gr (mvar u j)  = begin
+    eval (f _ u) (evals (subs f (reifys (build (λ x₁ → get g1 (j $ x₁))))) idEnv)
+        ≡⟨ cong (λ ts → eval (f _ u) (evals ts idEnv)) (reifys-nats {f = f} (evalAs-nats g j)) ⟩
     eval (f _ u) (evals (reifys (build (λ z → get g2 (j $ z)))) idEnv)
-        ≡⟨ eval-ext (f _ u) (RelA-unfold idEnv (precompose-∘ idEnv gr j)) ⟩
-    eval (f _ u) (build (λ z → get g2 (j $ z))) 
+        ≡⟨ eval-ext (f _ u) (RelA-unfold idEnv {g = build (λ z → get g2 (j $ z))} {h = build (λ z → get g2 (j $ z))} (precompose-∘ idEnv {g = g2} {h = g2} gr j)) ⟩
+    eval (f _ u) (build (λ z → get g2 (j $ z)))
         ≡⟨ sym (eval-tri (f _ u) j (λ x → ≡-d (get-build (λ v → get g2 (j $ v)) x))) ⟩
-    eval (ren j (f _ u)) g2 ∎  
- 
+    eval (ren j (f _ u)) g2 ∎
+
   eval-nats {_} {false} {f = f} {g1} {g2} g gr (mvar u ts) = begin
     replace (f _ u) (subs f (reifys (evals ts g1)))          ≡⟨ cong (replace (f _ u)) (reifys-nats {f = f} (evals-nats g gr ts)) ⟩
     nf (f _ u) (evals (reifys (evals (subs f ts) g2)) idEnv) ≡⟨ sym
                                                                   (nf-∘ (f _ u) g2
                                                                    (λ {S} x →
-                                                                      transR S (evals-∘ g2 (idEnv-∘ g2) (subs f ts) x)
-                                                                      (symd _ (RelA-unfold idEnv (evals-∘ idEnv gr (subs f ts)) x)))) ⟩
+                                                                      transR S (evals-∘ g2 {g = idEnv} {h = g2} (idEnv-∘ g2) (subs f ts) x)
+                                                                      (symd _ (RelA-unfold idEnv {g = evals (subs f ts) g2} {h = evals (subs f ts) g2} (evals-∘ idEnv gr (subs f ts)) x)))) ⟩
     nf (nf (f _ u) (evals (subs f ts) idEnv)) g2             ∎
 
 
-  evals-nats : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2} 
+  evals-nats : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2}
                → Env-nats f g1 g2 → RelId g2 → (t : Tms< b2 > Sg G1 D2 T) → Env-nats f (evals t g1) (evals (subs f t) g2)
   evals-nats enat gr []       = _
   evals-nats enat gr (x ∷ xs) = eval-nats enat gr x , evals-nats enat gr xs
 
-  evalAs-nats : ∀ {b1 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2} 
+  evalAs-nats : ∀ {b1 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2}
                 → Env-nats f g1 g2 → (t : Args true Sg G1 D2 T) → Env-nats f (evalAs t g1) (evalAs t g2)
   evalAs-nats g []             = _
   evalAs-nats g (i ∷ t [ pf ]) = get-nats g i , evalAs-nats g t
-  
-  expand-nats : ∀ {b1 Sg G1 G2 D B} Ss {f : Sub< b1 > Sg G1 G2}{c1 c2} 
-                → (∀ D r {xs ys} → Env-nats f xs ys → sub f (proj₁ c1 D r xs) ≡ proj₁ c2 D r ys) 
+
+  expand-nats : ∀ {b1 Sg G1 G2 D B} Ss {f : Sub< b1 > Sg G1 G2}{c1 c2}
+                → (∀ D r {xs ys} → Env-nats f xs ys → sub f (proj₁ c1 D r xs) ≡ proj₁ c2 D r ys)
                 → Dom-nats {D = D} (Ss ->> B) f (expand Ss c1) (expand Ss c2)
   expand-nats []       h = h _ id-i _
   expand-nats (S ∷ Ss) h = λ D1 r sr x₁ → expand-nats Ss (λ D r₁ eq → h D (r₁ ∘i r) (mapDom-nats S r₁ x₁ , eq))
 
   injv-nats : ∀ {b1 Sg G1 G2 D T} {f : Sub< b1 > Sg G1 G2} → (v : D ∋ T) → Dom-nats T f (injv v) (injv v)
   injv-nats {T = _ ->> _} v = expand-nats _ (λ D r x → cong (var _) (reifys-nats x))
-   
-  reify-nats : ∀ {b1 Sg G1 G2 D1} T {f : Sub< b1 > Sg G1 G2} {t1 : (Dom Sg G1 D1) T}{t2 : (Dom Sg G2 D1) T} 
+
+  reify-nats : ∀ {b1 Sg G1 G2 D1} T {f : Sub< b1 > Sg G1 G2} {t1 : (Dom Sg G1 D1) T}{t2 : (Dom Sg G2 D1) T}
                → Dom-nats T f t1 t2 → sub f (reify T t1) ≡ reify T t2
   reify-nats ([]       ->> _) t = t
   reify-nats ((S ∷ Ss) ->> _) t = cong lam (reify-nats (Ss ->> _) (t _ (weak id-i) (injv-∘ S idEnv zero (injv zero) (refld _)) (injv-nats zero)))
@@ -144,11 +144,11 @@ mutual
   reifys-nats {g1 = []}     {[]}     eq = refl
   reifys-nats {g1 = x ∷ xs} {y ∷ ys} eq = cong₂ _∷_ (reify-nats _ (proj₁ eq)) (reifys-nats (proj₂ eq))
 
-  nf-nats : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2} 
+  nf-nats : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2}
             → Env-nats f g1 g2 → RelId g2 → (t : Tm< b2 > Sg G1 D2 T) → sub f (nf t g1) ≡ nf (sub f t) g2
   nf-nats enat gr t = reify-nats _ (eval-nats enat gr t)
 
-  nfs-nats : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2} 
+  nfs-nats : ∀ {b1 b2 Sg G1 G2 D1 D2 T} {f : Sub< b1 > Sg G1 G2} {g1 : All (Dom Sg G1 D1) D2}{g2 : All (Dom Sg G2 D1) D2}
            →  Env-nats f g1 g2 → RelId g2 → (t : Tms< b2 > Sg G1 D2 T) → subs f (nfs t g1) ≡ nfs (subs f t) g2
   nfs-nats g gr []       = refl
   nfs-nats g gr (x ∷ xs) = cong₂ _∷_ (nf-nats g gr x) (nfs-nats g gr xs)
@@ -163,8 +163,8 @@ mutual
   mapEnv-nats [] [] i e = _
   mapEnv-nats (x ∷ xs) (y ∷ ys) i (s , e) = mapDom-nats _ i s , mapEnv-nats xs ys i e
 
-  $$-nats : ∀ {Sg G G1 D Ts B b} (s : Sub< b > Sg G G1) 
-             {f1 : Dom Sg G D (Ts ->> B)} {f2 : Dom Sg G1 D (Ts ->> B)} {xs : All (Dom Sg G D) Ts} {xs1 : All (Dom Sg G1 D) Ts} →  
+  $$-nats : ∀ {Sg G G1 D Ts B b} (s : Sub< b > Sg G G1)
+             {f1 : Dom Sg G D (Ts ->> B)} {f2 : Dom Sg G1 D (Ts ->> B)} {xs : All (Dom Sg G D) Ts} {xs1 : All (Dom Sg G1 D) Ts} →
              Dom-nats (Ts ->> B) s f1 f2 → Env-nats s xs xs1 → RelId xs1 → Dom-nats (! B) s (f1 $$ xs) (f2 $$ xs1)
   $$-nats s {xs = []}      {[]}      dnat enat gr = dnat
   $$-nats s {xs = px ∷ xs} {py ∷ ys} dnat enat gr = $$-nats s (dnat _ id-i (gr zero) (proj₁ enat)) (proj₂ enat) (\ x → gr (suc x))
@@ -177,4 +177,3 @@ mutual
 
   idEnv-nats : ∀ {D b Sg G1 G2} {f : Sub< b > Sg G1 G2} → Env-nats f (idEnv {D = D}) idEnv
   idEnv-nats = build-nats _ _ injv injv injv-nats
-

--- a/Unification/Injections.agda
+++ b/Unification/Injections.agda
@@ -21,12 +21,12 @@ module _ {A : Set} where
 -- difference is that Pullbacks allow for mediating permutations while
 -- Equalizers don't.
 --
--- The implementation takes a bit of record field's shuffling but it's straightforward.  
+-- The implementation takes a bit of record field's shuffling but it's straightforward.
 
 abstract
-  e$u≡m : ∀ {A : Set}{S T : List A}{f g : Inj S T} -> (equ : Equalizer f g) -> let open Equalizer equ in 
+  e$u≡m : ∀ {A : Set}{S T : List A}{f g : Inj S T} -> (equ : Equalizer f g) -> let open Equalizer equ in
                (a : A) (m : S ∋ a) → f $ m ≡ g $ m → Σ (E ∋ a) (λ u → m ≡ e $ u)
-  e$u≡m equ a m eq =  
+  e$u≡m equ a m eq =
     let
         open Equalizer equ
         [m] = m ∷ [] [ _ ]
@@ -35,38 +35,39 @@ abstract
 
   p$u≡q : ∀ {A : Set} {X Y Z : List A}(f : Inj X Z)(g : Inj Y Z) -> (p : Pullback f g) -> let open Pullback p in
       (a : A) (q₂ : Y ∋ a) (q₁ : X ∋ a) → f $ q₁ ≡ g $ q₂ → Σ (P ∋ a) (λ u → p₁ $ u ≡ q₁ × p₂ $ u ≡ q₂)
-  p$u≡q f g p a q₂ q₁ eq = 
+  p$u≡q f g p a q₂ q₁ eq =
    let
     open Pullback p
     [q₁] = q₁ ∷ [] [ _ ]
     [q₂] = q₂ ∷ [] [ _ ]
     u : Inj (a ∷ []) P
     u = universal [q₁] [q₂] (ext-∘ (λ {._ zero → eq; _ (suc ())}))
-   in u $ zero , 
-      trans (sym (apply-∘ p₁ u)) (cong (λ f₁ → f₁ $ zero) p₁∘universal≡q₁) , 
-      trans (sym (apply-∘ p₂ u)) (cong (λ f₁ → f₁ $ zero) p₂∘universal≡q₂) 
+   in u $ zero ,
+      trans (sym (apply-∘ p₁ u)) (cong (λ f₁ → f₁ $ zero) p₁∘universal≡q₁) ,
+      trans (sym (apply-∘ p₂ u)) (cong (λ f₁ → f₁ $ zero) p₂∘universal≡q₂)
 
 
 []-unique : ∀ {A : Set}{Q : List A}{f g : Inj [] Q} -> f ≡ g
 []-unique {f = []}{[]} = refl
-    
+
 
 weak-equalizer : ∀ {A : Set}{a : A}{S T : List A}(f g : Inj S T){E e} -> IsEqualizer f g E e -> IsEqualizer (weak {x = a} f) (weak g) E e
-weak-equalizer {a = a} f g {E} {e} equ = 
+weak-equalizer {a = a} f g {E} {e} equ =
    record {
      commutes = trans (Inj-thin-∘i zero f e) (trans (cong (Inj-thin zero) commutes)
                                                 (sym (Inj-thin-∘i zero g e)));
-     universal = λ m commutes₁ → universal m 
+     universal = λ m commutes₁ → universal m
                (Inj-thin-inj zero (f ∘i m) (g ∘i m) (trans (sym (Inj-thin-∘i zero f m)) (trans commutes₁ (Inj-thin-∘i zero g m))));
      universal-unique = universal-unique;
      e∘universal≡m = e∘universal≡m }
   where
     open IsEqualizer equ
 
+infix 40 _→zero∷e⇒i∷f,i∷g
 
-_→zero∷e⇒i∷f,i∷g : ∀ {A : Set}{a : A}{S T : List A}{v : T ∋ a}{f g : Inj S T}{pf pg}{E e} -> 
+_→zero∷e⇒i∷f,i∷g : ∀ {A : Set}{a : A}{S T : List A}{v : T ∋ a}{f g : Inj S T}{pf pg}{E e} ->
                IsEqualizer f g E e -> IsEqualizer (v ∷ f [ pf ]) (v ∷ g [ pg ]) (a ∷ E) (zero ∷[] e)
-_→zero∷e⇒i∷f,i∷g {a = a} {v = u} {f} {g} {pf} {pg} {E} {e} equ = 
+_→zero∷e⇒i∷f,i∷g {a = a} {v = u} {f} {g} {pf} {pg} {E} {e} equ =
    record {
      commutes = ext-∘ aux;
      universal = λ m commutes₁ → proj₁ (uni m commutes₁);
@@ -78,7 +79,7 @@ _→zero∷e⇒i∷f,i∷g {a = a} {v = u} {f} {g} {pf} {pg} {E} {e} equ =
     aux .a zero = refl
     aux x (suc v) rewrite Inj-thin-$ {x = a} zero e v = ∘-ext commutes _ v
     uni : {Q : _} (m : Inj Q _) → (u ∷ f [ pf ]) ∘i m ≡ (u ∷ g [ pg ]) ∘i m → Σ (Inj Q (a ∷ E)) (λ z → (zero ∷[] e) ∘i z ≡ m )
-    uni = 
+    uni =
       Equ-universal-quote (u ∷ f [ pf ]) (u ∷ g [ pg ]) (zero ∷[] e)
         (∋-case (λ x → zero , refl)
          (λ a₁ y x →
@@ -86,10 +87,10 @@ _→zero∷e⇒i∷f,i∷g {a = a} {v = u} {f} {g} {pf} {pg} {E} {e} equ =
             in suc (proj₁ rec) ,
                trans (cong suc (proj₂ rec))
                (sym (Inj-thin-$ zero e (proj₁ (e$u≡m (Equ _ , _ , equ) a₁ y x))))))
-    
+
 
 cons-equalizer : ∀ {A : Set}{a : A}{S T : List A}(f g : Inj S T) -> Equalizer f g -> Equalizer (cons {x = a} f) (cons g)
-cons-equalizer {A} {a} f g (Equ E , e , equ) = Equ _ , _ , (weak-equalizer f g equ) →zero∷e⇒i∷f,i∷g
+cons-equalizer {A} {a} f g (Equ E , e , equ) = Equ _ , _ , ((weak-equalizer f g equ) →zero∷e⇒i∷f,i∷g)
 
 eta-empty : ∀ {A : Set}{Q : List A}(f g : Inj Q []) -> f ≡ g
 eta-empty [] [] = refl
@@ -102,21 +103,23 @@ empty-equalizer {A} = record {
                     universal-unique = λ u e∘u≡m → eta-empty _ _;
                     e∘universal≡m = eta-empty _ _ }
 
-_,_→weake⇒i∷f,j∷g : ∀ {A : Set}{a : A}{S T : List A}{u v : T ∋ a} -> u ≢ v -> 
+infixr 40 _,_→weake⇒i∷f,j∷g
+
+_,_→weake⇒i∷f,j∷g : ∀ {A : Set}{a : A}{S T : List A}{u v : T ∋ a} -> u ≢ v ->
                ∀ {f g : Inj S T}{pf pg}{E e} -> IsEqualizer f g E e -> IsEqualizer (u ∷ f [ pf ]) (v ∷ g [ pg ]) E (weak e)
-_,_→weake⇒i∷f,j∷g {a = a} {u = u}{v} u≢v {f} {g} {pf} {pg} {E} {e} equ = 
+_,_→weake⇒i∷f,j∷g {a = a} {u = u}{v} u≢v {f} {g} {pf} {pg} {E} {e} equ =
        record {
          commutes = ext-∘ aux;
          universal = λ m commutes₁ → proj₁ (uni m commutes₁);
          universal-unique = λ {Q} {m} {commutes₁} u₁ e∘u≡m → ∘i-inj (weak e) u₁ _ (trans e∘u≡m (sym (proj₂ (uni m commutes₁))));
          e∘universal≡m = \ {Q} {m} {comm} -> proj₂ (uni m comm) }
- where 
+ where
    open IsEqualizer equ
    aux : (x : _) (v₁ : E ∋ x) → (u ∷ f [ pf ]) $ (weak e $ v₁) ≡ (v ∷ g [ pg ]) $ (weak e $ v₁)
    aux x v₁ rewrite Inj-thin-$ {x = a} zero e v₁ = ∘-ext commutes _ v₁
 
    uni : {Q : _} (m : Inj Q _) → (u ∷ f [ pf ]) ∘i m ≡ (v ∷ g [ pg ]) ∘i m → Σ (Inj Q E) (λ z → (weak e) ∘i z ≡ m )
-   uni = Equ-universal-quote (u ∷ f [ pf ]) (v ∷ g [ pg ]) (weak e) (∋-case (λ u≡v → ⊥-elim (u≢v u≡v)) 
+   uni = Equ-universal-quote (u ∷ f [ pf ]) (v ∷ g [ pg ]) (weak e) (∋-case (λ u≡v → ⊥-elim (u≢v u≡v))
                    (λ a₁ y x →
                         let rec : _
                             rec = e$u≡m (Equ _ , _ , equ) a₁ y x
@@ -147,34 +150,34 @@ empty-pullback {A} {X} {Z} {f} = record {
    proof {.[]} {q₁} {[]} = []-unique
    proof {._} {q₁} {() ∷ q₂ [ pf ]}
 
-∈-pullback : ∀ {A : Set} {X Y Z P : List A} {f : Inj X Z}{g : Inj Y Z}{p₁ p₂} -> IsPullback f g P p₁ p₂ -> 
+∈-pullback : ∀ {A : Set} {X Y Z P : List A} {f : Inj X Z}{g : Inj Y Z}{p₁ p₂} -> IsPullback f g P p₁ p₂ ->
              ∀ {a x pf x∉p₁ } → IsPullback f ((f $ x) ∷ g [ pf ]) (a ∷ P) (x ∷ p₁ [ x∉p₁ ]) (zero ∷[] p₂)
 ∈-pullback {A}{X}{Y}{Z}{P}{f = f} {g} {p₁}{p₂}pull{a}{x}{pf}{x∉p₁}  = record {
                     commutes = ext-∘ aux;
                     universal = λ q₁ q₂ commutes₁ → proj₁ (uni q₁ q₂ commutes₁);
-                    universal-unique = λ u p₁∘u≡q₁ p₂∘u≡q₂ → 
+                    universal-unique = λ u p₁∘u≡q₁ p₂∘u≡q₂ →
                         ∘i-inj (x ∷ p₁ [ x∉p₁ ]) u (proj₁ (uni _ _ _)) (trans p₁∘u≡q₁ (proj₁ (proj₂ (uni _ _ _))));
                     p₁∘universal≡q₁ = sym (proj₁ (proj₂ (uni _ _ _)));
                     p₂∘universal≡q₂ = sym (proj₂ (proj₂ (uni _ _ _))) }
   where
     open IsPullback pull
     abstract
-      uni : ∀ {Q} -> (q₁ : Inj Q X) (q₂ : Inj Q (a ∷ Y)) -> f ∘i q₁ ≡ ((f $ x) ∷ g [ pf ]) ∘i q₂ -> 
-          ∃ \ u -> q₁ ≡ (x ∷ p₁ [ x∉p₁ ]) ∘i u × q₂ ≡ (zero ∷[] p₂) ∘i u  
-      uni {Q} q₁ q₂ eq = Pull-universal-quote f ((f $ x) ∷ g [ pf ]) (x ∷ p₁ [ x∉p₁ ]) (zero ∷[] p₂)  
-            (∋-case (λ x₁ x₂ → zero , ((injective f x x₁ (sym x₂)) , refl)) (λ a₁ y x₁ x₂ → 
-            let p : Σ _ _; p = p$u≡q f g (Pull P , p₁ , p₂ , pull) a₁ y x₁ x₂ 
-            in (suc (proj₁ p)) , (proj₁ (proj₂ p)) , (trans (iso2 _ _ (proj₁ p)) (cong suc (proj₂ (proj₂ p)))))) 
+      uni : ∀ {Q} -> (q₁ : Inj Q X) (q₂ : Inj Q (a ∷ Y)) -> f ∘i q₁ ≡ ((f $ x) ∷ g [ pf ]) ∘i q₂ ->
+          ∃ \ u -> q₁ ≡ (x ∷ p₁ [ x∉p₁ ]) ∘i u × q₂ ≡ (zero ∷[] p₂) ∘i u
+      uni {Q} q₁ q₂ eq = Pull-universal-quote f ((f $ x) ∷ g [ pf ]) (x ∷ p₁ [ x∉p₁ ]) (zero ∷[] p₂)
+            (∋-case (λ x₁ x₂ → zero , ((injective f x x₁ (sym x₂)) , refl)) (λ a₁ y x₁ x₂ →
+            let p : Σ _ _; p = p$u≡q f g (Pull P , p₁ , p₂ , pull) a₁ y x₁ x₂
+            in (suc (proj₁ p)) , (proj₁ (proj₂ p)) , (trans (iso2 _ _ (proj₁ p)) (cong suc (proj₂ (proj₂ p))))))
             q₁ q₂ eq
 
     aux : ∀ t (v : _ ∋ t) -> f $ ((x ∷ p₁ [ x∉p₁ ]) $ v) ≡
       ((f $ x) ∷ g [ pf ]) $
-      ((zero ∷[] p₂) $ v) 
+      ((zero ∷[] p₂) $ v)
     aux .a zero = refl
     aux t (suc v) = trans (∘-ext (IsPullback.commutes pull) _ v) (cong (_$_ ((f $ x) ∷ g [ pf ])) (sym (Inj-thin-$ zero p₂ v)))
-  
 
-comm-pullback : ∀ {A : Set} {X Y Z P : List A} {f : Inj X Z}{g : Inj Y Z}{p₁ p₂} -> IsPullback f g P p₁ p₂ -> 
+
+comm-pullback : ∀ {A : Set} {X Y Z P : List A} {f : Inj X Z}{g : Inj Y Z}{p₁ p₂} -> IsPullback f g P p₁ p₂ ->
                  IsPullback g f P p₂ p₁
 comm-pullback pull = record {
                        commutes = sym commutes;
@@ -182,45 +185,45 @@ comm-pullback pull = record {
                        universal-unique = λ u p₁∘u≡q₁ p₂∘u≡q₂ → universal-unique u p₂∘u≡q₂ p₁∘u≡q₁;
                        p₁∘universal≡q₁ = p₂∘universal≡q₂;
                        p₂∘universal≡q₂ = p₁∘universal≡q₁ }
-  where 
+  where
     open IsPullback pull
 
 
-∉-pullback : ∀ {A : Set} {X Y Z P : List A} {f : Inj X Z}{g : Inj Y Z}{p₁ p₂} -> IsPullback f g P p₁ p₂ -> 
+∉-pullback : ∀ {A : Set} {X Y Z P : List A} {f : Inj X Z}{g : Inj Y Z}{p₁ p₂} -> IsPullback f g P p₁ p₂ ->
              ∀ {a} {i : Z ∋ a} {pf} → i ∉Im f -> IsPullback f (i ∷ g [ pf ]) P p₁ (weak p₂)
 ∉-pullback {A}{X}{Y}{Z}{f = f} {g = g} {p₁}{p₂}pull {a} {i} {pf} i∉f = record {
-                        commutes = trans commutes (ext-∘ (λ x v →  
+                        commutes = trans commutes (ext-∘ (λ x v →
                                                   cong (_$_ (_ ∷ g [ _ ])) (sym (Inj-thin-$ zero p₂ v))));
                         universal = λ q₁ q₂ commutes₁ → proj₁ (uni q₁ q₂ commutes₁);
                         universal-unique = λ u p₁∘u≡q₁ p₂∘u≡q₂ → ∘i-inj p₁ u (proj₁ (uni _ _ _)) (trans p₁∘u≡q₁ (proj₁ (proj₂ (uni _ _ _))));
                         p₁∘universal≡q₁ = sym (proj₁ (proj₂ (uni _ _ _)));
                         p₂∘universal≡q₂ = sym (proj₂ (proj₂ (uni _ _ _))) }
-   where 
-     open IsPullback pull 
+   where
+     open IsPullback pull
      abstract
-       uni : ∀ {Q} -> (q₁ : Inj Q X) (q₂ : Inj Q (a ∷ Y)) -> f ∘i q₁ ≡ (i ∷ g [ pf ]) ∘i q₂ -> ∃ \ u -> q₁ ≡ p₁ ∘i u × q₂ ≡ (weak p₂) ∘i u  
-       uni {Q} q₁ q₂ eq = Pull-universal-quote f (i ∷ g [ pf ]) p₁ (weak p₂) (∋-case (λ x x₁ → ⊥-elim (i∉f x (sym x₁))) 
+       uni : ∀ {Q} -> (q₁ : Inj Q X) (q₂ : Inj Q (a ∷ Y)) -> f ∘i q₁ ≡ (i ∷ g [ pf ]) ∘i q₂ -> ∃ \ u -> q₁ ≡ p₁ ∘i u × q₂ ≡ (weak p₂) ∘i u
+       uni {Q} q₁ q₂ eq = Pull-universal-quote f (i ∷ g [ pf ]) p₁ (weak p₂) (∋-case (λ x x₁ → ⊥-elim (i∉f x (sym x₁)))
          (λ a₁ y x x₁ → let p : Σ _ _
                             p = p$u≡q f g (Pull _ , p₁ , p₂ , pull) a₁ y x x₁
-                        in (proj₁ p) , ((proj₁ (proj₂ p)) , trans (iso2 _ _ (proj₁ p)) (cong suc (proj₂ (proj₂ p)))))) 
+                        in (proj₁ p) , ((proj₁ (proj₂ p)) , trans (iso2 _ _ (proj₁ p)) (cong suc (proj₂ (proj₂ p))))))
          q₁ q₂ eq
 
 pullback : ∀ {A : Set} {X Y Z : List A} → (f : Inj X Z)(g : Inj Y Z) → Pullback f g
 pullback f [] = Pull [] , [] , [] , empty-pullback
-pullback f (i ∷ g [ pf ]) with invert f i | pullback f g 
-pullback f (.(f $ x) ∷ g [ pf ]) | yes (x , refl) | Pull P , p₁ , p₂ , p₁,p₂⇒f,g = 
+pullback f (i ∷ g [ pf ]) with invert f i | pullback f g
+pullback f (.(f $ x) ∷ g [ pf ]) | yes (x , refl) | Pull P , p₁ , p₂ , p₁,p₂⇒f,g =
                                                     Pull (_ ∷ P) , (x ∷ p₁ [ x∉p₁ ]) , (zero ∷[] p₂) , ∈-pullback p₁,p₂⇒f,g
   where
     open IsPullback p₁,p₂⇒f,g
     x∉p₁ : x ∉ p₁
-    x∉p₁ = ∉Im-∉ p₁ x λ b x≡k$b → ∉-∉Im g (f $ x) pf (p₂ $ b) 
-              (begin f $ x        ≡⟨ cong (_$_ f) x≡k$b ⟩ 
-                     f $ (p₁ $ b) ≡⟨ ∘-ext commutes _ b ⟩ 
+    x∉p₁ = ∉Im-∉ p₁ x λ b x≡k$b → ∉-∉Im g (f $ x) pf (p₂ $ b)
+              (begin f $ x        ≡⟨ cong (_$_ f) x≡k$b ⟩
+                     f $ (p₁ $ b) ≡⟨ ∘-ext commutes _ b ⟩
                      g $ (p₂ $ b) ∎)
-pullback f (i ∷ g [ pf ])        | no i∉f         | Pull P , p₁ , p₂ , p₁,p₂⇒f,g = 
+pullback f (i ∷ g [ pf ])        | no i∉f         | Pull P , p₁ , p₂ , p₁,p₂⇒f,g =
                                                     Pull P , p₁ , weak p₂ , ∉-pullback p₁,p₂⇒f,g (λ b x → i∉f (b , (sym x)))
 
-weak-pullback : ∀ {A : Set} {X Y Z P : List A} {f : Inj X Z}{g : Inj Y Z}{p₁ p₂} -> IsPullback f g P p₁ p₂ -> 
+weak-pullback : ∀ {A : Set} {X Y Z P : List A} {f : Inj X Z}{g : Inj Y Z}{p₁ p₂} -> IsPullback f g P p₁ p₂ ->
                 ∀ {a : A} -> IsPullback (weak {x = a} f) (weak g) P p₁ p₂
 weak-pullback pull = record {
                        commutes = trans (Inj-thin-∘i zero _ _)
@@ -237,7 +240,5 @@ weak-pullback pull = record {
     open IsPullback pull
 
 cons-pullback : ∀ {A : Set}{a : A}{X Y Z : List A}(f : Inj X Z)(g : Inj Y Z) -> Pullback f g -> Pullback (cons {x = a} f) (cons g)
-cons-pullback {A} {a} f g (Pull P , p₁ , p₂ , p₁,p₂⇒f,g) = Pull a ∷ P , cons p₁ , cons p₂ , 
+cons-pullback {A} {a} f g (Pull P , p₁ , p₂ , p₁,p₂⇒f,g) = Pull a ∷ P , cons p₁ , cons p₂ ,
               ∈-pullback (comm-pullback (∉-pullback (comm-pullback (weak-pullback p₁,p₂⇒f,g)) (∉-∉Im (weak g) zero (v∉Inj-thinv zero g))))
-
-

--- a/Unification/MetaRens.agda
+++ b/Unification/MetaRens.agda
@@ -1,13 +1,15 @@
+{-# OPTIONS --allow-unsolved-metas #-}
+
 module Unification.MetaRens where
 
 open import Data.Empty
 open import Data.Sum
-open import Data.List.All
+open import Data.List.Relation.Unary.All using (All; []; _∷_)
 
 open import Support.Equality
 open ≡-Reasoning
 
-open import Vars.MatchTwo 
+open import Vars.MatchTwo
 open import Vars.SumIso
 open import Injections
 open import MetaRens hiding (_⋆_)
@@ -18,7 +20,7 @@ open import Unification.Injections
 
 record ESub (Sg : Ctx) (G : MCtx) (G1 : MCtx) : Set where
   constructor ι_
-  field 
+  field
     {cond} : Bool
     ⟦_⟧ : Sub< cond > Sg G G1
 
@@ -46,15 +48,15 @@ module ESubop {Sg} = Category MCtx (λ X Y → ESub Sg Y X) (λ f g → g ∘e f
 module ESubop2 {Sg} = Category MCtx (λ X Y → ESub Sg Y X) (λ f g → g ∘e f) id-e (\ f g -> ∀ S x -> ⟦ f ⟧ S x ≡d ⟦ g ⟧ S x)
 
 module ESubopProps {Sg : Ctx} where
-  module X = ESubop {Sg} 
+  module X = ESubop {Sg}
   module D = X.Props (\ {A} {B} {C} {D} {f} {g} {h} -> ES λ S u → cong-↓↓ (∧-assoc {cond h}) (Sub∘.sub-∘ (⟦ h ⟧ S u)))
-                     (λ {A} {B} {f} -> ES \ S u → cong ↓↓ (ren-id (⟦ f ⟧ S u))) 
-                     (λ {A} {B} {f} -> ES \ S u → cong-↓↓ (Subid.x∧true≡x {cond f}) (Subid.sub-id (⟦ f ⟧ S u))) 
+                     (λ {A} {B} {f} -> ES \ S u → cong ↓↓ (ren-id (⟦ f ⟧ S u)))
+                     (λ {A} {B} {f} -> ES \ S u → cong-↓↓ (Subid.x∧true≡x {cond f}) (Subid.sub-id (⟦ f ⟧ S u)))
                      (λ {A} {B} →
                           record {
                           refl = ES λ S x₁ → refl;
                           sym = λ x -> ES \ S x₁ → sym ([]eq x _ _);
-                          trans = λ x x₁ -> ES \ S x₂ → trans ([]eq x S x₂) ([]eq x₁ S x₂) }) 
+                          trans = λ x x₁ -> ES \ S x₂ → trans ([]eq x S x₂) ([]eq x₁ S x₂) })
                      (λ { {A} {B} {C} {ι f} {ι h} {ι g} {ι i} eq1 eq2 -> ES \ S u →
                           trans (cong-sub g {f S u} {h S u} ([]eq eq1 S u)) (sub-extd g i (h S u) ([]eq eq2))})
   open D public
@@ -70,7 +72,7 @@ module Mixed {Sg : Ctx} where
       isPullback : X.IsPullback (toESub f) (toESub g) P (toESub p₁) (toESub p₂)
 
     open X.IsPullback isPullback public
-    
+
     to-sub : X.Pullback (toESub f) (toESub g)
     to-sub = X.Pull P , toESub p₁ , toESub p₂ , isPullback
 
@@ -110,9 +112,9 @@ eta-inj : ∀ {Sg G S} -> (c1 c2 : VarClosure G S) -> eta {Sg} c1 ≡ eta c2 -> 
 eta-inj (i / v) (.i / .v) refl = refl
 
 ↓ : ∀ {Sg G S} -> VarClosure G S -> Tm< false > Sg G (ctx S) (! type S)
-↓ cl = ↓↓ (eta cl) 
+↓ cl = ↓↓ (eta cl)
 
- 
+
 ↓-inj : ∀ {Sg G S} -> (c1 c2 : VarClosure G S) -> ↓ {Sg} c1 ≡ ↓ c2 -> c1 ≡ c2
 ↓-inj c1 c2 eq = eta-inj c1 c2 (↓↓-inj eq)
 
@@ -127,9 +129,9 @@ epic-from-sub f f-epic {C} {g1} {g2} eq S u = ↓-inj _ _
         S u)
 
 epic-to-sub2 : ∀ {X Y Sg} -> (f : MetaRen X Y) -> MRop.Monic f -> ESubop2.Monic {Sg} (toESub f)
-epic-to-sub2 f f-epic {C} {g1} {g2} eq S u 
- with epic-inv f f-epic S u 
-... | (_ , y , j , eq')                                   with f _ y    | eq _ y 
+epic-to-sub2 f f-epic {C} {g1} {g2} eq S u
+ with epic-inv f f-epic S u
+... | (_ , y , j , eq')                                   with f _ y    | eq _ y
 epic-to-sub2 f f-epic {C} {g1} {g2} eq S u | _ , y , j , refl | .(j / u) | z = ren-injd j (⟦ g1 ⟧ S u) (⟦ g2 ⟧ S u) z
 
 epic-to-sub : ∀ {X Y Sg} -> (f : MetaRen X Y) -> MRop.Monic f -> ESubop.Monic {Sg} (toESub f)
@@ -142,18 +144,18 @@ mutual
   lift-equalizer equ (con c ts) (con refl eq) = con c (lifts-equalizer equ ts eq)
   lift-equalizer {true} equ (mvar u j₁) (mvar refl eq) = mvar u ((universal j₁ eq) , e∘universal≡m)
     where open Equalizer equ
-  lift-equalizer {false} equ (mvar u ts) (mvar refl eq) = mvar u (lifts-equalizer equ ts (≡-T eq)) 
+  lift-equalizer {false} equ (mvar u ts) (mvar refl eq) = mvar u (lifts-equalizer equ ts (≡-T eq))
   lift-equalizer equ (var x ts) (var eqv eqts) = var (proj₁ r) (sym (proj₂ r)) (lifts-equalizer equ ts eqts)
     where r = e$u≡m equ _ x eqv
   lift-equalizer equ (lam t) (lam eq) = lam (lift-equalizer (cons-equalizer _ _ equ) t eq)
 
-  lifts-equalizer : ∀ {Sg G X Y S b} {i j : Inj X Y} (equ : Equalizer i j) (t : Tms< b > Sg G X S) → 
+  lifts-equalizer : ∀ {Sg G X Y S b} {i j : Inj X Y} (equ : Equalizer i j) (t : Tms< b > Sg G X S) →
                     let open Equalizer equ in rens i t ≡T rens j t → e ⁻¹ t
   lifts-equalizer equ [] eq = []
   lifts-equalizer equ (t ∷ ts) (eqt ∷ eqts) = lift-equalizer equ t eqt ∷ lifts-equalizer equ ts eqts
 
 mutual
-  lift-pullback : ∀ {b X Y Z} {i : Inj X Z}{j : Inj Y Z} (pull : Pullback i j) → let open Pullback pull in 
+  lift-pullback : ∀ {b X Y Z} {i : Inj X Z}{j : Inj Y Z} (pull : Pullback i j) → let open Pullback pull in
                   ∀ {Sg G T} (t : Tm< b > Sg G _ T) s → ren i t ≡T ren j s → p₂ ⁻¹ s
   lift-pullback pull (con c ts) (mvar u j₁) ()
   lift-pullback pull (con c ts) (var x ts₁) ()
@@ -168,20 +170,20 @@ mutual
     where open Pullback pull
   lift-pullback {false} pull (mvar u q₁) (mvar .u q₂)  (mvar refl eq) = mvar u (lifts-pullback pull q₁ q₂ (≡-T eq))
   lift-pullback pull (var x ts) (var x₁ ts₁) (var i$x≡j$x₁ eqts) = var (proj₁ r) (proj₂ (proj₂ r)) (lifts-pullback pull ts ts₁ eqts)
-    where r = p$u≡q _ _ pull _ x₁ x i$x≡j$x₁ 
+    where r = p$u≡q _ _ pull _ x₁ x i$x≡j$x₁
 
-  lifts-pullback : ∀ {b X Y Z} {i : Inj X Z}{j : Inj Y Z} (pull : Pullback i j) → let open Pullback pull in 
+  lifts-pullback : ∀ {b X Y Z} {i : Inj X Z}{j : Inj Y Z} (pull : Pullback i j) → let open Pullback pull in
                   ∀ {Sg G T} (t : Tms< b > Sg G _ T) s → rens i t ≡T rens j s → p₂ ⁻¹ s
   lifts-pullback pull []       []         eq           = []
   lifts-pullback pull (t ∷ ts) (t₁ ∷ ts₁) (eqt ∷ eqts) = (lift-pullback pull t t₁ eqt) ∷ (lifts-pullback pull ts ts₁ eqts)
 
-lift-pullback-other : ∀ {b X Y Z} {i : Inj X Z}{j : Inj Y Z} (pull : Pullback i j) → let open Pullback pull in 
-                      ∀ {Sg G T} (t : Tm< b > Sg G _ T) s → ren i t ≡ ren j s → (p₂⁻¹s : p₂ ⁻¹ s) 
+lift-pullback-other : ∀ {b X Y Z} {i : Inj X Z}{j : Inj Y Z} (pull : Pullback i j) → let open Pullback pull in
+                      ∀ {Sg G T} (t : Tm< b > Sg G _ T) s → ren i t ≡ ren j s → (p₂⁻¹s : p₂ ⁻¹ s)
                       -> let z = proj₁ (forget p₂⁻¹s) in ren p₁ z ≡ t
 lift-pullback-other {i = i} {j = j} pull t s eq p₂⁻¹s = ren-inj i _ _
                                                           (trans (sym (ren-∘ z))
                                                            (trans (cong (λ j₁ → ren j₁ z) commutes)
-                                                            (trans (ren-∘ _) 
+                                                            (trans (ren-∘ _)
                                                              (trans (cong (ren j) ren[p₂,z]≡s) (sym eq)))))
   where
     open Pullback pull
@@ -189,22 +191,22 @@ lift-pullback-other {i = i} {j = j} pull t s eq p₂⁻¹s = ren-inj i _ _
     ren[p₂,z]≡s = proj₂ (forget p₂⁻¹s)
 
 coequalizer-step : ∀ {τ Z X} (f : All (VarClosure X) Z)(g : All (VarClosure X) Z) {Sg} ->
-                 (equ : Mixed.Coequalizer {Sg} (eval f) (eval g)) → let open Mixed.Coequalizer equ in 
+                 (equ : Mixed.Coequalizer {Sg} (eval f) (eval g)) → let open Mixed.Coequalizer equ in
                  ∀ (u v : VarClosure X τ) (eu : VarClosure E (type τ <<- Ψ u)) (ev : VarClosure E (type τ <<- Ψ v))
                  → eu ≈vc e _ (body u) → ev ≈vc e _ (body v)
                  → Mixed.Coequalizer {Sg} (eval (u ∷ f)) (eval (v ∷ g))
-coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (jev / ev) eu≈e[u] ev≈e[v] with thick[ eu , ev ]-refl₂ 
-coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (jev / .eu) (vc refl eq2 eq3) (vc eq4 eq5 eq6) | one refl , eq₁ 
-  = Mixed.Equ E' , e' , 
+coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (_/_ {Ψ₄} i u) (_/_ {Ψ₃} j v) (_/_ {Ψ₂} ieu eu) (_/_ {Ψ₁} jev ev) eu≈e[u] ev≈e[v] with thick[ eu , ev ]-refl₂
+coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (_/_ {Ψ₄} i u) (_/_ {Ψ₃} j v) (_/_ {Ψ₂} ieu eu) (_/_ {Ψ₁} jev ev) (vc refl eq2 eq3) (vc eq4 eq5 eq6) | one refl , eq₁
+  = Mixed.Equ E' , e' ,
     (record {
        commutes = ES (∋-case (cong ↓ commz) (λ a y → cong ↓ (comms a y)));
        universal = λ m m-comm → ι Universal.universal' m m-comm;
        universal-unique = λ {Q} {m} {m-comm} x y → ES (Universal.universal-unique' m m-comm {cond x} ⟦ x ⟧ ([]eq y));
-       e∘universal≡m = \ {Q} {m} {m-comm} -> ES (Universal.universal∘e'≡m m m-comm) }) 
+       e∘universal≡m = \ {Q} {m} {m-comm} -> ES (Universal.universal∘e'≡m m m-comm) })
   where
    open Mixed.Coequalizer equ
    equ0 = equalizer (i ∘i ieu) (j ∘i jev)
-  
+
    E' : MCtx
    E' = τ <<- _ ∷ E -[ eu , eu ]
 
@@ -229,18 +231,29 @@ coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (je
    commutes-mr S y = (↓-inj (bind e ((eval f S y))) (bind e ((eval g S y))) ([]eq commutes S y))
 
    commz' : map-Vc i (bind e'' (ieu / eu)) ≡ map-Vc j (bind e'' (jev / eu))
-   commz' rewrite thick[ eu , eu ]-refl = cong₂ _/_ (trans assoc-∘i (trans (Equalizer.commutes equ0) (sym assoc-∘i))) refl
+   -- commz' = {! thick[ eu , eu ]-refl !}
+   -- commz' rewrite thick[ eu , eu ]-refl = cong₂ _/_ (trans assoc-∘i (trans (Equalizer.commutes equ0) (sym assoc-∘i))) refl
+   commz' = cong₂ _/_ (trans assoc-∘i (trans  aux (sym assoc-∘i))) refl
+     where
+       aux : ((i ∘i ieu) ∘i e'' (τ <<- Ψ (e (τ <<- Ψ₄) u)) eu .ρ-env) ≡
+             ((j ∘i jev) ∘i e'' (τ <<- Ψ (e (τ <<- Ψ₄) u)) eu .ρ-env)
+       -- aux eu with thick[ eu , eu ] eu |  thick[ eu , eu ]-refl
+       -- ... | z | eq  = {!!}
+       -- aux = {! thick[ eu , eu ]-refl !}
+       aux = {!!}
+       -- This is rejected by Agda 2.9.0:
+       -- aux rewrite thick[ eu , eu ]-refl = Equalizer.commutes equ0
 
    commz : map-Vc i (bind e'' (e _ u)) ≡ map-Vc j (bind e'' (e _ v))
    commz = subst₂ (λ eu ev → map-Vc i (bind e'' eu) ≡ map-Vc j (bind e'' ev)) (promote eu≈e[u]) (promote ev≈e[v]) commz'
 
    comms : (e' ∘mr eval f) ≡mr (e' ∘mr eval g)
    comms S y with e _ (body (eval f S y))  | e _ (body (eval g S y)) | to-vc (commutes-mr S y)
-   comms S y    | _ / .w                   | _ / w                   | vc refl eq7 refl 
+   comms S y    | _ / .w                   | _ / w                   | vc refl eq7 refl
      = cong₂ _/_ (trans assoc-∘i (trans (cong (λ j₁ → j₁ ∘i ρ-env (e'' _ w)) (≅-to-≡ eq7)) (sym assoc-∘i))) refl
 
    module Universal {Q : List MTy} (m : ESub Sg X Q)
-      (m-comm : (m ∘e toESub (eval ((i / u) ∷ f))) ≡e (m ∘e toESub (eval ((j / v) ∷ g)))) where 
+      (m-comm : (m ∘e toESub (eval ((i / u) ∷ f))) ≡e (m ∘e toESub (eval ((j / v) ∷ g)))) where
 
     uni = ⟦ universal m (ES (λ S₁ x₁ → []eq m-comm S₁ (suc x₁))) ⟧
     buni = cond (universal m (ES (λ S₁ x₁ → []eq m-comm S₁ (suc x₁))))
@@ -249,15 +262,15 @@ coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (je
     abstract
       uni⋆e[u],uni⋆e[v]⇒i,j : ren i (uni ⋆ (ieu / eu)) ≡d
                               ren j (uni ⋆ (jev / eu))
-      uni⋆e[u],uni⋆e[v]⇒i,j = 
-        subst₂ (\ a b → ren i (uni ⋆ a) ≡d ren j (uni ⋆ b)) (sym (promote eu≈e[u])) (sym (promote ev≈e[v])) 
+      uni⋆e[u],uni⋆e[v]⇒i,j =
+        subst₂ (\ a b → ren i (uni ⋆ a) ≡d ren j (uni ⋆ b)) (sym (promote eu≈e[u])) (sym (promote ev≈e[v]))
                  (trans (cong-ren {b1 = buni} {b2 = cond m} i (e∘uni≡m _ u))
                    (trans ([]eq m-comm _ zero)
                    (sym (cong-ren {b1 = buni} {b2 = cond m} j (e∘uni≡m _ v)))))
 
       uni[eu]⇒i∘ieu,j∘jev : ren (i ∘i ieu) (uni _ eu) ≡d ren (j ∘i jev) (uni _ eu)
       uni[eu]⇒i∘ieu,j∘jev = trans (cong ↓↓ (ren-∘ (uni _ eu))) (trans uni⋆e[u],uni⋆e[v]⇒i,j (sym (cong ↓↓ (ren-∘ (uni _ eu)))))
-    
+
     equ0⁻¹uni[eu] = forget (lift-equalizer equ0 (uni _ eu) (≡-T (↓↓-inj uni[eu]⇒i∘ieu,j∘jev)))
 
     universal' : Sub< _ > Sg E' Q
@@ -268,18 +281,18 @@ coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (je
     universal∘e'≡m S x       with e _ x     | thick[ eu , eu ] (body (e _ x)) | e∘uni≡m _ x
     universal∘e'≡m S x          | jex / ex  | neither w eq                    | pr rewrite eq | right-id jex = pr
     universal∘e'≡m (.τ <<- _) x | jex / ex  | one⊎other (other neq eq)        | pr = ⊥-elim (neq refl eq)
-    universal∘e'≡m (.τ <<- _) x | jex / .eu | one⊎other (one refl)            | pr 
+    universal∘e'≡m (.τ <<- _) x | jex / .eu | one⊎other (one refl)            | pr
                    = trans (cong ↓↓ (trans (ren-∘ _) (cong (ren _) (proj₂ equ0⁻¹uni[eu])))) pr
 
     universal-unique' : ∀ {b} -> (u : Sub< b > Sg E' Q) (e∘u≡m : ∀ S x -> (u ∘s toSub e') S x ≡d ⟦ m ⟧ S x) → ∀ S x -> u S x ≡d universal' S x
-    universal-unique' {b} u₁ u∘e'≡m ._ zero    
+    universal-unique' {b} u₁ u∘e'≡m ._ zero
       = ren-injd {b1 = b} {b2 = buni} (ieu ∘i Equalizer.e equ0) _ _
           (begin
            ↓↓ (u₁ ⋆ ((ieu ∘i Equalizer.e equ0) / zero)) ≡⟨ cong ↓↓ (sym (cong (_⋆_ u₁) e'[u]≡e/zero)) ⟩
            ↓↓ (u₁ ⋆ e' _ u)                             ≡⟨ u∘e'≡m _ u ⟩
            ↓↓ (⟦ m ⟧ _ u)                               ≡⟨ sym (e∘uni≡m _ u) ⟩
            ↓↓ (uni ⋆ e _ u)                             ≡⟨ cong ↓↓ (cong (_⋆_ uni) (sym (promote eu≈e[u]))) ⟩
-           ↓↓ (uni ⋆ (ieu / eu))                        ≡⟨ cong ↓↓ (sym (trans (ren-∘ _) (cong (ren _) (proj₂ equ0⁻¹uni[eu])))) ⟩ 
+           ↓↓ (uni ⋆ (ieu / eu))                        ≡⟨ cong ↓↓ (sym (trans (ren-∘ _) (cong (ren _) (proj₂ equ0⁻¹uni[eu])))) ⟩
            ↓↓ (ren (ieu ∘i Equalizer.e equ0) (proj₁ equ0⁻¹uni[eu]))  ∎)
     universal-unique' u₁ u∘e'≡m  S (suc x) = trans (cong ↓↓ u₁∘suc≡u₂∘thin) ([]eq (universal-unique (ι u₂) (ES u₂∘e≡m)) S (thin[ eu , eu ] x))
       where
@@ -298,8 +311,8 @@ coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (je
         u₂∘e≡m (._ <<- _) x₁ | jex / ex | one⊎other (other neq eq)        | qq = ⊥-elim (neq refl eq)
         u₂∘e≡m S₁ x₁         | jex / ex | neither w eq                    | qq rewrite right-id jex = qq
 
-... | other neq eq , eq₁ 
- = Mixed.Equ E' , e' , 
+... | other neq eq , eq₁
+ = Mixed.Equ E' , e' ,
     (record {
        commutes = ES (∋-case (cong ↓ commz) (λ a y → cong ↓ (comms a y)));
        universal = λ m m-comm → ι Universal.universal' m m-comm;
@@ -329,17 +342,18 @@ coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (je
    commutes-mr S y = (↓-inj (bind e ((eval f S y))) (bind e ((eval g S y))) ([]eq commutes S y))
 
    commz' : map-Vc i (bind e'' (ieu / eu)) ≡ map-Vc j (bind e'' (jev / ev))
-   commz' rewrite thick[ eu , ev ]-refl 
-    with thick[ eu , ev ] ev | thick[ eu , ev ]-refl₂₂ neq
-   ... | ._                  | (_ , refl) 
-     = cong₂ _/_ (trans assoc-∘i (trans (Pullback.commutes pull0) (sym assoc-∘i))) refl
+   commz' = {!!}
+   -- commz' rewrite thick[ eu , ev ]-refl
+   --  with thick[ eu , ev ] ev | thick[ eu , ev ]-refl₂₂ neq
+   -- ... | ._                  | (_ , refl)
+   --   = cong₂ _/_ (trans assoc-∘i (trans (Pullback.commutes pull0) (sym assoc-∘i))) refl
 
    commz : map-Vc i (bind e'' (e _ u)) ≡ map-Vc j (bind e'' (e _ v))
    commz rewrite sym (promote eu≈e[u]) | sym (promote ev≈e[v]) = commz'
 
    comms : ∀ S y → bind e' (eval f S y) ≡ bind e' (eval g S y)
    comms S y with e _ (body (eval f S y))  | e _ (body (eval g S y)) | to-vc (commutes-mr S y)
-   comms S y    | _ / .w                   | _ / w                   | vc refl eq7 refl 
+   comms S y    | _ / .w                   | _ / w                   | vc refl eq7 refl
       = cong₂ _/_ (trans assoc-∘i
                      (trans (cong (λ j₁ → j₁ ∘i ρ-env (e'' _ w)) (≅-to-≡ eq7))
                       (sym assoc-∘i))) refl
@@ -355,13 +369,13 @@ coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (je
     abstract
       uni⋆e[u],uni⋆e[v]⇒i,j : ren i (uni ⋆ (ieu / eu)) ≡d
                               ren j (uni ⋆ (jev / ev))
-      uni⋆e[u],uni⋆e[v]⇒i,j = 
-        (subst₂ (\ a b → ren i (uni ⋆ a) ≡d ren j (uni ⋆ b)) (sym (promote eu≈e[u])) (sym (promote ev≈e[v])) 
-                        (trans (cong-ren {b1 = buni} {b2 = cond m} i (e∘uni≡m _ u)) 
-                        (trans ([]eq m-comm _ zero) 
+      uni⋆e[u],uni⋆e[v]⇒i,j =
+        (subst₂ (\ a b → ren i (uni ⋆ a) ≡d ren j (uni ⋆ b)) (sym (promote eu≈e[u])) (sym (promote ev≈e[v]))
+                        (trans (cong-ren {b1 = buni} {b2 = cond m} i (e∘uni≡m _ u))
+                        (trans ([]eq m-comm _ zero)
                           (sym (cong-ren {b1 = buni} {b2 = cond m} j (e∘uni≡m _ v))))))
 
-      uni[eu],uni[ev]⇒i∘ieu,j∘jev : ren (i ∘i ieu) (uni _ eu) ≡d 
+      uni[eu],uni[ev]⇒i∘ieu,j∘jev : ren (i ∘i ieu) (uni _ eu) ≡d
                                     ren (j ∘i jev) (uni _ ev)
       uni[eu],uni[ev]⇒i∘ieu,j∘jev = trans (cong ↓↓ (ren-∘ (uni _ eu))) (trans uni⋆e[u],uni⋆e[v]⇒i,j (sym (cong ↓↓ (ren-∘ (uni _ ev)))))
 
@@ -370,8 +384,8 @@ coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (je
     z = proj₁ (forget p₂⁻¹uni[ev])
 
     ren[p₂,z]≡uni[ev] = proj₂ (forget p₂⁻¹uni[ev])
-    ren[p₁,z]≡uni[eu] = lift-pullback-other pull0 (uni _ eu) (uni _ ev) (↓↓-inj uni[eu],uni[ev]⇒i∘ieu,j∘jev) p₂⁻¹uni[ev] 
-                     
+    ren[p₁,z]≡uni[eu] = lift-pullback-other pull0 (uni _ eu) (uni _ ev) (↓↓-inj uni[eu],uni[ev]⇒i∘ieu,j∘jev) p₂⁻¹uni[ev]
+
     universal' : Sub< _ > Sg E' Q
     universal' ._ zero    = z
     universal'  S (suc x) = uni S (thin[ eu , ev ] x)
@@ -391,8 +405,8 @@ coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (je
            ↓↓ (u₁ ⋆ e' _ u)                              ≡⟨ u∘e'≡m _ u ⟩
            ↓↓ (⟦ m ⟧ _ u)                                ≡⟨ sym (e∘uni≡m _ u) ⟩
            ↓↓ (uni ⋆ e _ u)                              ≡⟨ cong ↓↓ (cong (_⋆_ uni) (sym (promote eu≈e[u]))) ⟩
-           ↓↓ (uni ⋆ (ieu / eu))                         ≡⟨ cong ↓↓ (sym (trans (ren-∘ _) (cong (ren ieu) ren[p₁,z]≡uni[eu]))) ⟩ 
-           ↓↓ (ren (ieu ∘i Pullback.p₁ pull0) z)         ∎) 
+           ↓↓ (uni ⋆ (ieu / eu))                         ≡⟨ cong ↓↓ (sym (trans (ren-∘ _) (cong (ren ieu) ren[p₁,z]≡uni[eu]))) ⟩
+           ↓↓ (ren (ieu ∘i Pullback.p₁ pull0) z)         ∎)
 
     universal-unique' u₁ u∘e'≡m  S (suc x) = trans (cong ↓↓ u₁∘suc≡u₂∘thin) ([]eq (universal-unique (ι u₂) (ES u₂∘e≡m)) S (thin[ eu , ev ] x))
       where
@@ -411,22 +425,22 @@ coequalizer-step {τ <<- Ss} {Z} {X} f g {Sg} equ (i / u) (j / v) (ieu / eu) (je
         u₂∘e≡m (._ <<- _) x₁ | jex / ex | one⊎other (other neq eq)        | qq = trans (cong ↓↓ (sym (ren-∘ (u₁ _ zero)))) qq
         u₂∘e≡m S₁ x₁         | jex / ex | neither w eq                    | qq rewrite right-id jex = qq
 
-coequalizer : ∀ {Z X} → (f : All (VarClosure X) Z)(g : All (VarClosure X) Z) → ∀ {Sg} -> 
+coequalizer : ∀ {Z X} → (f : All (VarClosure X) Z)(g : All (VarClosure X) Z) → ∀ {Sg} ->
               Mixed.Coequalizer {Sg} (eval f) (eval g)
-coequalizer []          []          = Mixed.Equ _ , idmr , 
+coequalizer []          []          = Mixed.Equ _ , idmr ,
      (record {
         commutes = ES λ S x → refl;
         universal = λ m commutes → m;
         universal-unique = λ u e∘u≡m → ES (λ S x → trans (sym (cong ↓↓ (ren-id (⟦ u ⟧ S x)))) ([]eq e∘u≡m S x));
         e∘universal≡m = \ {Q} {m} -> ES λ S x → cong ↓↓ (ren-id (⟦ m ⟧ S x)) })
 coequalizer (i / u ∷ f) (j / v ∷ g) = coequalizer-step f g coequ (i / u) (j / v) (e _ u) (e _ v) (to-vc refl) (to-vc refl)
-  where 
-    coequ = coequalizer f g 
+  where
+    coequ = coequalizer f g
     open Mixed.Coequalizer coequ
 
 
 coproduct : ∀ {A B Sg} -> Mixed.Coproduct {Sg} A B
-coproduct {A} {B} {Sg} = Mixed.Prod (A ++ B) inl inr ⟨_,_⟩ 
+coproduct {A} {B} {Sg} = Mixed.Prod (A ++ B) inl inr ⟨_,_⟩
           (λ {_} {f} {g} → ES
                              (λ S x →
                                 trans (ren-id _)
@@ -454,16 +468,16 @@ coproduct {A} {B} {Sg} = Mixed.Prod (A ++ B) inl inr ⟨_,_⟩
 
   ⟨_,_⟩ : ∀ {C} → (ESub Sg A C) → (ESub Sg B C) → (ESub Sg (A ++ B) C)
   ⟨ f , g ⟩ = ι (λ S u → helper (down ⟦ f ⟧) (down ⟦ g ⟧) (split# A u))
- 
+
   universal : ∀ {C} {f : ESub Sg A C} {g : ESub Sg B C} {i : ESub Sg (A ++ B) C}
-               → (i ∘e toESub inl) ≡e f → (i ∘e toESub inr) ≡e g  → down ⟦ ⟨ f , g ⟩ ⟧ ≡s down ⟦ i ⟧ 
-  universal (i∘inl≡f) (i∘inr≡g) S x with split# A x | glue∘split≡id {_} {A} x 
+               → (i ∘e toESub inl) ≡e f → (i ∘e toESub inr) ≡e g  → down ⟦ ⟨ f , g ⟩ ⟧ ≡s down ⟦ i ⟧
+  universal (i∘inl≡f) (i∘inr≡g) S x with split# A x | glue∘split≡id {_} {A} x
   universal {i = ι i} (i∘inl≡f) (i∘inr≡g) S .(glue# A (inj₁ x)) | inj₁ x | refl = sym (trans (sym (cong ↓↓ (ren-id (i S _)))) ([]eq i∘inl≡f S x))
   universal {i = ι i} (i∘inl≡f) (i∘inr≡g) S .(glue# A (inj₂ y)) | inj₂ y | refl = sym (trans (sym (cong ↓↓ (ren-id (i S _)))) ([]eq i∘inr≡g S y))
 
 pushout' : ∀ {Z Y X Sg} → (f : MetaRen Z X)(g : MetaRen Z Y) → ESubop.Pullback {Sg} (toESub f) (toESub g)
-pushout' {Z} {Y} {X} {Sg} f g = ESubopProps.convert (toESub f) (toESub g) (Mixed.Coproduct.to-sub coprod) 
-                           (ESubopProps.Equalizer-ext (ES λ S u → cong ↓↓ (cong eta (proj₂ (reify (π₁ ∘mr f)) S u))) 
+pushout' {Z} {Y} {X} {Sg} f g = ESubopProps.convert (toESub f) (toESub g) (Mixed.Coproduct.to-sub coprod)
+                           (ESubopProps.Equalizer-ext (ES λ S u → cong ↓↓ (cong eta (proj₂ (reify (π₁ ∘mr f)) S u)))
                                                      (ES λ S u →  cong ↓↓ (cong eta (proj₂ (reify (π₂ ∘mr g)) S u)))
                               (Mixed.Coequalizer.to-sub
                                (coequalizer (proj₁ (reify (π₁ ∘mr f)))
@@ -478,4 +492,4 @@ abstract
     where
       open ESubop.Pullback (pushout' f g)
 
-
+-- -}

--- a/Unification/Specification.agda
+++ b/Unification/Specification.agda
@@ -6,7 +6,7 @@ open import Data.Sum renaming (inj₁ to yes; inj₂ to no)
 open import Support.Equality
 open ≡-Reasoning
 
-open import Injections
+open import Injections hiding (yes; no)
 
 open import Syntax
 
@@ -18,7 +18,7 @@ Property< b > Sg G = (∀ {G2} -> Sub< b > Sg G G2 -> Set)
 
 Property : ∀ Sg G -> Set₁
 Property Sg G = ∀ {b} -> Property< b > Sg G
- 
+
 Unifies : ∀ {Sg G1 D S} (x y : Term Sg G1 D S) -> Property Sg G1
 Unifies x y σ = subT σ x ≡T subT σ y
 
@@ -46,26 +46,26 @@ Spec x y = ∃⟦σ⟧ Max (Unifies x y) ⊎ ¬ ∃σ Unifies x y
 Unifies-ext : ∀ {Sg G1 D S} (x y : Term Sg G1 D S) -> ∀ {b} -> Extensional {b} (Unifies x y)
 Unifies-ext x y f≡g subfx≡subfy rewrite subT-ext f≡g x | subT-ext f≡g y = subfx≡subfy
 
-≤-∘ : ∀ {Sg g g1 g2 g3}(ρ : Sub< false > Sg g g1)(p : Sub Sg g g2)(q : Sub Sg g2 g3) -> (ρ≤p : ρ ≤ p) -> proj₁ ρ≤p ≤ q -> ρ ≤ (q ∘s p) 
-≤-∘ ρ p q (δ , ρ≡δ∘p) (δ' , δ'≡δ∘q) 
+≤-∘ : ∀ {Sg g g1 g2 g3}(ρ : Sub< false > Sg g g1)(p : Sub Sg g g2)(q : Sub Sg g2 g3) -> (ρ≤p : ρ ≤ p) -> proj₁ ρ≤p ≤ q -> ρ ≤ (q ∘s p)
+≤-∘ ρ p q (δ , ρ≡δ∘p) (δ' , δ'≡δ∘q)
   = δ' , λ S u → begin ρ S u                    ≡⟨ ρ≡δ∘p S u ⟩
-                       sub δ (p S u)            ≡⟨ sub-ext δ'≡δ∘q (p S u) ⟩ 
+                       sub δ (p S u)            ≡⟨ sub-ext δ'≡δ∘q (p S u) ⟩
                        subT (δ' ∘s q) (p S u)   ≡⟨ sym (Sub∘.subT-∘ (p S u)) ⟩
                        subT δ' (subT q (p S u)) ∎
 
 
 map-Unifies : ∀ {Sg g h h' d t} {σ : Sub Sg g h}{σ' : Sub Sg g h'}-> σ ≤ σ' -> {x y : Term Sg g d t} -> Unifies x y σ' -> Unifies x y σ
-map-Unifies {σ = σ} {σ'} (δ , σ≡δ∘σ') {x} {y} σ'Unifies[x,y] = ≡-T 
+map-Unifies {σ = σ} {σ'} (δ , σ≡δ∘σ') {x} {y} σ'Unifies[x,y] = ≡-T
          (begin subT σ x           ≡⟨ subT-ext σ≡δ∘σ' x ⟩
                 subT (δ ∘s σ') x   ≡⟨ T-≡ (sandwich subT-∘ (T.cong (subT δ) σ'Unifies[x,y])) ⟩
                 subT (δ ∘s σ') y   ≡⟨ sym (subT-ext σ≡δ∘σ' y) ⟩
                 subT σ y           ∎)
 
 
-shift_under_by_ : ∀ {Sg G h1 h2 D T} {xs ys : Term Sg G D T} {σ1 : Sub< false > Sg G h1} 
+shift_under_by_ : ∀ {Sg G h1 h2 D T} {xs ys : Term Sg G D T} {σ1 : Sub< false > Sg G h1}
                   -> Unifies xs ys σ1 -> (σ : Sub Sg G h2) -> σ1 ≤ σ -> ∃σ Unifies (subT σ xs) (subT σ ys)
-shift_under_by_ eq σ (δ , σ1≡δ∘σ) = _ , δ , sandwich (λ xs₁ → sym (trans (Sub∘.subT-∘ xs₁) 
-                                                        (sym (subT-ext σ1≡δ∘σ xs₁)))) 
+shift_under_by_ eq σ (δ , σ1≡δ∘σ) = _ , δ , sandwich (λ xs₁ → sym (trans (Sub∘.subT-∘ xs₁)
+                                                        (sym (subT-ext σ1≡δ∘σ xs₁))))
                                                      eq
 
 
@@ -82,12 +82,12 @@ cong-spec d (inj₂ no-unifier) = inj₂ (λ {(_ , σ , σ-unifies) → no-unifi
 
 optimist : ∀ {Sg m l o D T Ts}(x y : Tm Sg m D T)(xs ys : Tms Sg m D Ts) ->
            (p : Sub Sg m o) (q : Sub Sg o l) ->
-           Max (Unifies x y) p 
-           -> Max (Unifies (subT p xs) (subT p ys)) q 
+           Max (Unifies x y) p
+           -> Max (Unifies (subT p xs) (subT p ys)) q
            -> Max (Unifies (Tms._∷_ x xs) (y ∷ ys)) (q ∘s p)
 
-optimist x y xs ys p q ([p]Unifies[x,y] , sup-p) ([q]Unifies[px,py] , sup-q) = 
-             (map-Unifies (q , λ S u → refl) {x} {y} [p]Unifies[x,y] ∷ sandwich subT-∘ [q]Unifies[px,py]) , 
+optimist x y xs ys p q ([p]Unifies[x,y] , sup-p) ([q]Unifies[px,py] , sup-q) =
+             (map-Unifies (q , λ S u → refl) {x} {y} [p]Unifies[x,y] ∷ sandwich subT-∘ [q]Unifies[px,py]) ,
              (λ {ρ ([ρ]Unifies[x,y] ∷ [ρ]Unifies[xs,ys])
                      → let ρ≤p : _
                            ρ≤p = sup-p ρ [ρ]Unifies[x,y]
@@ -98,10 +98,10 @@ optimist x y xs ys p q ([p]Unifies[x,y] , sup-p) ([q]Unifies[px,py] , sup-q) =
                            δ≤q : _
                            δ≤q
                              = sup-q δ
-                               (sandwich (λ x₁ → sym (Sub∘.subT-∘ x₁)) 
+                               (sandwich (λ x₁ → sym (Sub∘.subT-∘ x₁))
                                (Unifies-ext xs ys ρ≡δ∘p [ρ]Unifies[xs,ys]))
                        in ≤-∘ ρ p q ρ≤p δ≤q})
-             
+
 
 
 ∃σMax[Unifies[x,x]] : ∀ {Sg G D T} (x : Term Sg G D T) -> ∃⟦σ⟧ Max (Unifies x x)
@@ -110,9 +110,9 @@ optimist x y xs ys p q ([p]Unifies[x,y] , sup-p) ([q]Unifies[px,py] , sup-q) =
                  refl-T _ ,
                  (λ ρ x₁ → ρ , (λ S u → sym (ren-id _)))
 
-Spec[xs,ys]⇒Spec[σxs,σys] : ∀ {Sg G G1 D T} {xs ys : Term Sg G D T} (σ : Sub Sg G G1) -> Ctx-length G ≡ Ctx-length G1 -> 
+Spec[xs,ys]⇒Spec[σxs,σys] : ∀ {Sg G G1 D T} {xs ys : Term Sg G D T} (σ : Sub Sg G G1) -> Ctx-length G ≡ Ctx-length G1 ->
                             IsIso σ -> Spec xs ys -> Spec (subT σ xs) (subT σ ys)
-Spec[xs,ys]⇒Spec[σxs,σys] {xs = xs} {ys = ys} σ G~G1 ((δ , id≡δ∘σ) , id≡σ∘δ) (yes (_ , σ₁ , [σ₁]Unifies[xs,ys] , sup-σ₁)) 
+Spec[xs,ys]⇒Spec[σxs,σys] {xs = xs} {ys = ys} σ G~G1 ((δ , id≡δ∘σ) , id≡σ∘δ) (yes (_ , σ₁ , [σ₁]Unifies[xs,ys] , sup-σ₁))
    = yes (_ , σ₁ ∘ds (DS δ , inj₁ (sym G~G1 , (σ , id≡σ∘δ) , id≡δ∘σ)) , [σ₁∘δ]Unifies[σxs,σys] , sup-[σ₁∘δ])
   where
     [σ₁∘δ]Unifies[σxs,σys] = sandwich (λ ys →
@@ -135,5 +135,5 @@ Spec[xs,ys]⇒Spec[σxs,σys] {xs = xs} {ys = ys} σ G~G1 ((δ , id≡δ∘σ) ,
        where
          ρ∘σ≤σ₁ = sup-σ₁ (ρ ∘s σ) (sandwich Sub∘.subT-∘ [ρ]Unifies[σxs,σys])
          δ' = proj₁ ρ∘σ≤σ₁
-      
+
 Spec[xs,ys]⇒Spec[σxs,σys] σ G~G1 _ (no ¬p) = no (λ {(_ , σ₁ , eq) → ¬p (_ , σ₁ ∘s σ , sandwich Sub∘.subT-∘ eq)})

--- a/Unification/Specification/Decr-Sub.agda
+++ b/Unification/Specification/Decr-Sub.agda
@@ -1,10 +1,10 @@
 module Unification.Specification.Decr-Sub where
 
 open import Data.Nat renaming (_≤_ to _≤ℕ_)
-open import Relation.Nullary
-open import Data.Nat.Properties
+open import Relation.Nullary using ()
+open import Data.Nat.Properties using (m≤n+m; +-mono-≤; +-*-commutativeSemiring; module ≤-Reasoning) renaming (m≤n⇒m≤1+n to ≤-step)
 open import Algebra
-open CommutativeSemiring commutativeSemiring using (+-comm; +-assoc)
+open CommutativeSemiring +-*-commutativeSemiring using (+-comm; +-assoc)
 open import Data.Sum
 
 open import Support.Equality
@@ -24,13 +24,13 @@ Ctx-length (type <<- ctx ∷ m) = suc (length ctx + Ctx-length m)
 
 IsIso : ∀ {Sg G1 G2} -> (s : Sub Sg G1 G2) -> Set
 IsIso s = Σ (∃ \ r -> id-s ≡s (r ∘s s)) \le -> id-s ≡s (s ∘s proj₁ le)
- 
+
 -- The substitutions we produce are going to either be isomorphims or
 -- produce terms in a smaller context, so it'll be fine to recurse on
 -- their results.
 Decreasing : ∀ {Sg G1 G2} -> (s : Sub Sg G1 G2) -> Set
-Decreasing {Sg} {G1} {G2} s = (Ctx-length G1 ≡ Ctx-length G2 × IsIso s) 
-                            ⊎ (Ctx-length G1 > Ctx-length G2) 
+Decreasing {Sg} {G1} {G2} s = (Ctx-length G1 ≡ Ctx-length G2 × IsIso s)
+                            ⊎ (Ctx-length G1 > Ctx-length G2)
 
 record DSub (Sg : Ctx) (G1 : MCtx) (G2 : MCtx) : Set where
   constructor DS_,_
@@ -45,17 +45,17 @@ open DSub public
 
 Ctx-length-lemma : ∀ {G Ss B} -> (u  : G ∋ B <<- Ss) -> Ctx-length G ≡ Ctx-length (G - u <: B <<- Ss)
 Ctx-length-lemma zero = refl
-Ctx-length-lemma {._ ∷ G} {Ss} (suc {S = _ <<- ctx} u) = 
+Ctx-length-lemma {._ ∷ G} {Ss} (suc {S = _ <<- ctx} u) =
   begin
     suc (length ctx) + Ctx-length G                           ≡⟨ cong (_+_ (suc (length ctx))) (Ctx-length-lemma u) ⟩
     suc (length ctx) + (suc (length Ss) + Ctx-length (G - u)) ≡⟨ sym (+-assoc (suc (length ctx)) (suc (length Ss)) _) ⟩
-    suc (length ctx) + suc (length Ss) + Ctx-length (G - u)   ≡⟨ cong (λ x → x + Ctx-length (G - u)) (+-comm (suc (length ctx)) (suc (length Ss))) ⟩ 
-    suc (length Ss) + suc (length ctx) + Ctx-length (G - u)   ≡⟨ +-assoc (suc (length Ss)) (suc (length ctx)) _ ⟩ 
+    suc (length ctx) + suc (length Ss) + Ctx-length (G - u)   ≡⟨ cong (λ x → x + Ctx-length (G - u)) (+-comm (suc (length ctx)) (suc (length Ss))) ⟩
+    suc (length Ss) + suc (length ctx) + Ctx-length (G - u)   ≡⟨ +-assoc (suc (length Ss)) (suc (length ctx)) _ ⟩
     suc (length Ss) + (suc (length ctx) + Ctx-length (G - u)) ∎
   where open ≡-Reasoning
 
 IsIso-id : ∀ {Sg G} -> IsIso {Sg} {G} {G} id-s
-IsIso-id = λ {Sg} {G} → (id-s , (λ S u → sym (ren-id _))) , (λ S u → sym (ren-id _))
+IsIso-id {Sg} {G} = (id-s , (λ S u → sym (ren-id _))) , (λ S u → sym (ren-id _))
 
 IsIso-∘ : ∀ {Sg G1 G2 G3} -> (s : Sub Sg G2 G3) -> (s' : Sub Sg G1 G2) -> IsIso s -> IsIso s' -> IsIso (s ∘s s')
 IsIso-∘ s s' ((δ , p) , p') ((δ' , q) , q') = (δ' ∘s δ ,
@@ -74,9 +74,9 @@ IsIso-∘ s s' ((δ , p) , p') ((δ' , q) , q') = (δ' ∘s δ ,
         sub s (δ S u)                   ≡⟨ cong (sub s) (sym (sub-id (δ S u))) ⟩
         sub s (sub id-s (δ S u))        ≡⟨ cong (sub s) (sub-ext q' (δ S u)) ⟩
         sub s (sub (s' ∘s δ') (δ S u))  ≡⟨ cong (sub s) (sym (sub-∘ {f = s'} {g = δ'} (δ S u))) ⟩
-        sub s (sub s' (sub δ' (δ S u))) ≡⟨ sub-∘ (sub δ' (δ S u)) ⟩ 
+        sub s (sub s' (sub δ' (δ S u))) ≡⟨ sub-∘ (sub δ' (δ S u)) ⟩
         sub (s ∘s s') (sub δ' (δ S u))  ∎)
-                                                   
+
   where open ≡-Reasoning
 
 trans-> : ∀ {m n o} -> m > n -> n > o -> m > o
@@ -86,25 +86,25 @@ trans-> (s≤s m≤n) (s≤s (s≤s m≤n₁)) = s≤s (trans-> m≤n (s≤s m�
 open ≤-Reasoning
 
 trans-dec : ∀ {Sg G1 G2 G3} -> (s : Sub Sg G2 G3) -> Decreasing s -> (s' : Sub Sg G1 G2) -> Decreasing s' -> Decreasing (s ∘s s')
-trans-dec s (inj₁ (G2~G3 , s-is-iso)) s' (inj₁ (G1~G2 , s'-is-iso )) 
+trans-dec s (inj₁ (G2~G3 , s-is-iso)) s' (inj₁ (G1~G2 , s'-is-iso ))
   = inj₁ (trans G1~G2 G2~G3 , IsIso-∘ s s' s-is-iso s'-is-iso )
-trans-dec {Sg} {G1} {G2} {G3} s (inj₁ (G2~G3 , _)) s' (inj₂ G1>G2) 
+trans-dec {Sg} {G1} {G2} {G3} s (inj₁ (G2~G3 , _)) s' (inj₂ G1>G2)
   = inj₂
       (begin
        suc (Ctx-length G3) ≡⟨ sym (cong suc G2~G3) ⟩
-       suc (Ctx-length G2) ≤⟨ G1>G2 ⟩ 
+       suc (Ctx-length G2) ≤⟨ G1>G2 ⟩
        Ctx-length G1       ∎)
-trans-dec {Sg} {G1} {G2} {G3} s (inj₂ G2>G3) s' (inj₁ (G1~G2 , _)) 
+trans-dec {Sg} {G1} {G2} {G3} s (inj₂ G2>G3) s' (inj₁ (G1~G2 , _))
   = inj₂
       (begin
        suc (Ctx-length G3) ≤⟨ G2>G3 ⟩
-       Ctx-length G2       ≡⟨ sym G1~G2 ⟩ 
+       Ctx-length G2       ≡⟨ sym G1~G2 ⟩
        Ctx-length G1       ∎)
-trans-dec s (inj₂ y) s' (inj₂ y₁) = inj₂ (trans-> y₁ y) 
+trans-dec s (inj₂ y) s' (inj₂ y₁) = inj₂ (trans-> y₁ y)
 
 _∘ds_ : ∀ {Sg G1 G2 G3} -> DSub Sg G2 G3 -> DSub Sg G1 G2 -> DSub Sg G1 G3
 (DS σ , G2>G3) ∘ds (DS σ₁ , G1>G2) = DS (σ ∘s σ₁) , trans-dec σ G2>G3 σ₁ G1>G2
-  
+
 ⟦⟧-∘ : ∀ {Sg g h i} (s : DSub Sg h i) (s₁ : DSub Sg g h) -> ⟦ s ∘ds s₁ ⟧ ≡s (⟦ s ⟧ ∘s ⟦ s₁ ⟧)
 ⟦⟧-∘ s s1 S x = refl
 
@@ -119,7 +119,7 @@ cons-id-≅i refl` = refl , ≡-to-≅ cons-id
 
 equalizer-Decr : ∀ {A : Set}{S T : List A}(f g : Inj S T) -> let open Equalizer (equalizer f g) in Decr-i e
 equalizer-Decr []            []             = inj₁ refl`
-equalizer-Decr (i ∷ f [ _ ]) ( j ∷ g [ _ ]) with i ≅∋? j | equalizer-Decr f g 
+equalizer-Decr (i ∷ f [ _ ]) ( j ∷ g [ _ ]) with i ≅∋? j | equalizer-Decr f g
 equalizer-Decr (i ∷ f [ _ ]) (.i ∷ g [ _ ]) | yes refl`  | inj₁ eq       = inj₁ (cons-id-≅i eq)
 equalizer-Decr (i ∷ f [ _ ]) (.i ∷ g [ _ ]) | yes refl`  | inj₂ gt       = inj₂ (s≤s gt)
 equalizer-Decr (i ∷ f [ _ ]) ( j ∷ g [ _ ]) | no  _      | inj₁ (eq , _) = inj₂ (s≤s (begin _ ≡⟨ cong length eq ⟩ _ ∎))
@@ -142,25 +142,25 @@ singleton-Decreasing {Sg} {G} {.Ss} {Ss} {B} .id-i u (inj₁ refl`) = inj₁ (Ct
   δ S (suc u₁) = mvar (thin u S u₁) id-i
 
   eq1 : id-s ≡s (δ ∘s toSub (singleton u id-i))
-  eq1 S u₁ with thick u u₁ 
+  eq1 S u₁ with thick u u₁
   eq1 S .(thin u S x) | inj₁ (x , refl) = cong (mvar _) (sym (right-id id-i))
   eq1 .(B <<- Ss) .u  | inj₂ refl`      = cong (mvar u) (sym (right-id id-i))
 
   eq2 : id-s ≡s (toSub (singleton u id-i) ∘s δ)
   eq2 ._ (zero {._} {.(_ <<- _)}) rewrite thick-refl u = cong (mvar _) (sym (right-id id-i))
   eq2 S (suc {._} {._} {.(_ <<- _)} v) rewrite thick-thin u v = cong (mvar _) (sym (right-id id-i))
-  
-singleton-Decreasing {Sg} {G} {E} {Ss} {B} e u (inj₂ Ss>E) 
+
+singleton-Decreasing {Sg} {G} {E} {Ss} {B} e u (inj₂ Ss>E)
   = inj₂
       (begin
-       suc (suc (length E) + Ctx-length (G - u)) ≤⟨ s≤s (Ss>E +-mono (begin Ctx-length (G - u) ∎)) ⟩
-       Ctx-length (G - u <: B <<- Ss)            ≡⟨ sym (Ctx-length-lemma u) ⟩ 
+       suc (suc (length E) + Ctx-length (G - u)) ≤⟨ s≤s (+-mono-≤ Ss>E (begin Ctx-length (G - u) ∎)) ⟩
+       Ctx-length (G - u <: B <<- Ss)            ≡⟨ sym (Ctx-length-lemma u) ⟩
        Ctx-length G                              ∎)
 
 rigid-decr : ∀ {G G1}{x}(u : G ∋ x) -> Ctx-length (G - u) ≥ Ctx-length G1
-                                    -> Ctx-length G > Ctx-length G1  
-rigid-decr {G} {G1} {type <<- ctx} u G-u≤G1 = 
-     begin suc (Ctx-length G1)                ≤⟨ s≤s G-u≤G1 ⟩ 
-           suc (Ctx-length (G - u))           ≤⟨ s≤s (n≤m+n (length ctx) (Ctx-length (G - u))) ⟩ 
-           Ctx-length (G - u <: type <<- ctx) ≡⟨ sym (Ctx-length-lemma u) ⟩ 
+                                    -> Ctx-length G > Ctx-length G1
+rigid-decr {G} {G1} {type <<- ctx} u G-u≤G1 =
+     begin suc (Ctx-length G1)                ≤⟨ s≤s G-u≤G1 ⟩
+           suc (Ctx-length (G - u))           ≤⟨ s≤s (m≤n+m (Ctx-length (G - u)) (length ctx)) ⟩
+           Ctx-length (G - u <: type <<- ctx) ≡⟨ sym (Ctx-length-lemma u) ⟩
            Ctx-length G                       ∎

--- a/Vars.agda
+++ b/Vars.agda
@@ -11,7 +11,7 @@ open import Support.Equality
 open ≡-Reasoning
 
 open import Relation.Nullary public using (Dec; yes; no; False; ¬_)
-open import Data.List public hiding ([_])
+open import Data.List public using (List; []; _∷_; length; _++_)
 
 infix 4 _∋_
 

--- a/Vars.agda
+++ b/Vars.agda
@@ -10,13 +10,13 @@ open import Data.Sum
 open import Support.Equality
 open ≡-Reasoning
 
-open import Relation.Nullary public
+open import Relation.Nullary public using (Dec; yes; no; False; ¬_)
 open import Data.List public hiding ([_])
 
 infix 4 _∋_
 
 -- Proofs of membership in lists
--- a.k.a. typed de Bruijn indices 
+-- a.k.a. typed de Bruijn indices
 -- i.e. our variable names.
 data _∋_ {A : Set} : List A → A → Set where
   zero : ∀ {G T} → T ∷ G ∋ T
@@ -37,14 +37,14 @@ _≅∋_ {A} {G} {S} {T} u v = S ≡ T × u ≅ v
 --   G ∋ T
 -- ≡ [T1 , .. , S , .. , Tn] ∋ T
 -- ≅ T1 ≡ T ⊎ .. ⊎ S ≡ T ⊎ .. ⊎ Tn ≡ T
--- ≅ (T1 ≡ T ⊎ .. ⊎ Tn ≡ T) ⊎ S ≡ T  
+-- ≅ (T1 ≡ T ⊎ .. ⊎ Tn ≡ T) ⊎ S ≡ T
 -- ≅ (G - u) ∋ T ⊎ S ≡ T
 --
 -- thin and thick below are the witnesses
 
 _-_ : ∀ {A T} → (G : List A) → G ∋ T → List A
 (T ∷ G) - zero  = G
-(S ∷ G) - suc x = S ∷ (G - x) 
+(S ∷ G) - suc x = S ∷ (G - x)
 
 infix 35 _-_
 
@@ -61,7 +61,7 @@ suc-inj1 : ∀ {A : Set}{xs : List A}{x z} {i : xs ∋ x}{j : xs ∋ x} → _∋
 suc-inj1 refl = refl
 
 x∉thinx : ∀ {A} {G : List A}{S} → (x : G ∋ S) → (y : (G - x) ∋ S) -> x ≡ thin x S y -> ⊥
-x∉thinx zero    y    () 
+x∉thinx zero    y    ()
 x∉thinx (suc x) zero ()
 x∉thinx (suc x) (suc y) eq = x∉thinx x y (suc-inj1 eq)
 
@@ -83,8 +83,8 @@ thick-thin (suc x) zero = refl
 thick-thin (suc x) (suc y) rewrite thick-thin x y = refl
 
 thin-inj : ∀ {A : Set}{xs : List A}{x y : A} -> (v : xs ∋ x) -> {i j : (xs - v) ∋ y} -> thin v y i ≡ thin v y j -> i ≡ j
-thin-inj v {i} {j} eq with cong (\ x -> maybe′ (\ x -> Maybe.just (proj₁ x)) nothing (isInj₁ (thick v x))) eq 
-... | p rewrite thick-thin v i | thick-thin v j with p 
+thin-inj v {i} {j} eq with cong (\ x -> maybe′ (\ x -> Maybe.just (proj₁ x)) nothing (isInj₁ (thick v x))) eq
+... | p rewrite thick-thin v i | thick-thin v j with p
 thin-inj v {i} {.i} eq | p | refl = refl
 
 _≅∋?_ : ∀ {A : Set} {G : List A} {S} (u : G ∋ S) {T} (v : G ∋ T) -> Dec (u ≅∋ v)
@@ -93,13 +93,13 @@ u ≅∋? v         with thick u v
 _≅∋?_ {S = S} u ._ | inj₁ (w , refl) = no (aux w) where
   aux : ∀ {T} (w : _ ∋ T) -> Σ (S ≡ T) (λ x → u ≅ thin u T w) → ⊥
   aux w (refl , eq) = x∉thinx u w (≅-to-≡ eq)
- 
+
 
 any? : ∀ {A : Set}{G : List A}{P : ∀ {S} -> G ∋ S -> Set} -> (∀ {S} v -> Dec (P {S} v)) -> Dec (∃ \ S -> ∃ (P {S}))
 any? {_} {[]}    dec = no (\ {(_ , () , _)})
-any? {_} {S ∷ G} dec 
+any? {_} {S ∷ G} dec
  with dec zero | any? (\ v -> dec (suc v))
 ... | yes p    | _               = yes (_ , zero , p)
 ... | no ¬p    | yes (T , v , p) = yes (T , suc v , p)
-... | no ¬p    | no ¬q           = no  λ {(._ , zero , p) → ¬p p; 
+... | no ¬p    | no ¬q           = no  λ {(._ , zero , p) → ¬p p;
                                           (_ , suc v , p) → ¬q (_ , v , p)}


### PR DESCRIPTION
Hej Andrea @Saizan, I made an attempt to port this repo to latest Agda but ran out of steam.
If you decide to port it, you can maybe take this as starting point.
Agda's unification has changed a bit, so there are some implicits needed that Agda 2.3.2 would infer.

UPDATE: putting the implicits in is tedious by mechanical, so I did a lot of them, but now I got stuck at failing `rewrite`s.